### PR TITLE
Fix for PTaH update

### DIFF
--- a/addons/sourcemod/scripting/weapons/hooks.sp
+++ b/addons/sourcemod/scripting/weapons/hooks.sp
@@ -27,7 +27,7 @@ public void UnhookPlayer(int client)
 		SDKUnhook(client, SDKHook_OnTakeDamageAlive, OnTakeDamageAlive);
 }
 
-public Action GiveNamedItemPre(int client, char classname[64], CEconItemView &item, bool &ignoredCEconItemView)
+public Action GiveNamedItemPre(int client, char classname[64], CEconItemView &item, bool &ignoredCEconItemView, bool &OriginIsNULL, float Origin[3])
 {
 	if (IsValidClient(client))
 	{
@@ -41,7 +41,7 @@ public Action GiveNamedItemPre(int client, char classname[64], CEconItemView &it
 	return Plugin_Continue;
 }
 
-public void GiveNamedItem(int client, const char[] classname, const CEconItemView item, int entity)
+public void GiveNamedItem(int client, const char[] classname, const CEconItemView item, int entity, bool OriginIsNULL, const float Origin[3])
 {
 	if (IsValidClient(client) && IsValidEntity(entity))
 	{


### PR DESCRIPTION
PTaH got an update a couple days ago, and a few functions got a couple additional parameters, including a few that are used in this plugin. This PR fixes the compilation error with the updated PTaH include.

PTaH Update: https://github.com/komashchenko/PTaH/commit/0160986f4b4de740dcb5aa00d293b40bbbb051f8