### PR TITLE
fix error log

### DIFF
--- a/addons/sourcemod/scripting/weapons/menus.sp
+++ b/addons/sourcemod/scripting/weapons/menus.sp
@@ -87,7 +87,7 @@ public Action WeaponsMenuTimer(Handle timer, DataPack pack)
 	int clientIndex = GetClientOfUserId(pack.ReadCell());
 	int menuSelectionPosition = pack.ReadCell();
 	
-	if(IsClientInGame(clientIndex))
+	if(IsValidClient(clientIndex))
 	{
 		int menuTime;
 		if((menuTime = GetRemainingGracePeriodSeconds(clientIndex)) >= 0)


### PR DESCRIPTION
```
L 03/10/2019 - 18:38:00: [SM] Exception reported: Client index 0 is invalid
L 03/10/2019 - 18:38:00: [SM] Blaming: weapons.smx
L 03/10/2019 - 18:38:00: [SM] Call stack trace:
L 03/10/2019 - 18:38:00: [SM]   [0] IsClientInGame
L 03/10/2019 - 18:38:00: [SM]   [1] Line 90, weapons/menus.sp::WeaponsMenuTimer
```

Fixes this occasional error log