### PR TITLE
add seed/allskins options

### DIFF
--- a/addons/sourcemod/scripting/weapons.sp
+++ b/addons/sourcemod/scripting/weapons.sp
@@ -79,6 +79,7 @@ public void OnPluginStart()
 	RegConsoleCmd("sm_knife", CommandKnife);
 	RegConsoleCmd("sm_nametag", CommandNameTag);
 	RegConsoleCmd("sm_wslang", CommandWSLang);
+	RegConsoleCmd("sm_seed", CommandSeedMenu);
 	
 	PTaH(PTaH_GiveNamedItemPre, Hook, GiveNamedItemPre);
 	PTaH(PTaH_GiveNamedItemPost, Hook, GiveNamedItemPost);
@@ -107,6 +108,30 @@ public Action CommandWeaponSkins(int client, int args)
 		}
 		else
 		{
+			PrintToChat(client, " %s \x02%t", g_ChatPrefix, "GracePeriod", g_iGracePeriod);
+		}
+	}
+	return Plugin_Handled;
+}
+
+public Action CommandSeedMenu(int client, int args)
+{
+	if (IsValidClient(client)) {
+		int curWep = GetEntPropEnt(client, Prop_Data, "m_hActiveWeapon");
+		if (!IsValidEntity(curWep) || !g_iSkins[client][GetWeaponIndex(curWep)])
+        {
+			PrintToChat(client, " %s Please equip a skinned weapon!", g_ChatPrefix);
+			return Plugin_Handled;
+		}
+        g_iIndex[client] = GetWeaponIndex(curWep);
+
+		int menuTime;
+		if((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
+        {
+			CreateSeedMenu(client).Display(client, menuTime);
+		}
+        else
+        {
 			PrintToChat(client, " %s \x02%t", g_ChatPrefix, "GracePeriod", g_iGracePeriod);
 		}
 	}
@@ -168,7 +193,7 @@ void SetWeaponProps(int client, int entity)
 		SetEntProp(entity, Prop_Send, "m_iItemIDHigh", IDHigh++);
 		SetEntProp(entity, Prop_Send, "m_nFallbackPaintKit", g_iSkins[client][index] == -1 ? GetRandomSkin(client, index) : g_iSkins[client][index]);
 		SetEntPropFloat(entity, Prop_Send, "m_flFallbackWear", !g_bEnableFloat || g_fFloatValue[client][index] == 0.0 ? 0.000001 : g_fFloatValue[client][index] == 1.0 ? 0.999999 : g_fFloatValue[client][index]);
-		SetEntProp(entity, Prop_Send, "m_nFallbackSeed", GetRandomInt(0, 8192));
+		SetEntProp(entity, Prop_Send, "m_nFallbackSeed", g_iWeaponSeed[client][index] == -1 ? (g_iSeedRandom[client][index] = GetRandomInt(0, 8192)) : g_iWeaponSeed[client][index]);
 		if(!IsKnife(entity))
 		{
 			if(g_bEnableStatTrak)

--- a/addons/sourcemod/scripting/weapons.sp
+++ b/addons/sourcemod/scripting/weapons.sp
@@ -60,15 +60,17 @@ public void OnPluginStart()
 	LoadTranslations("weapons.phrases");
 	
 	g_Cvar_DBConnection 			= CreateConVar("sm_weapons_db_connection", 			"storage-local", 	"Database connection name in databases.cfg to use");
-	g_Cvar_TablePrefix 			= CreateConVar("sm_weapons_table_prefix", 			"", 				"Prefix for database table (example: 'xyz_')");
-	g_Cvar_ChatPrefix 			= CreateConVar("sm_weapons_chat_prefix", 			"[oyunhost.net]", 	"Prefix for chat messages");
+	g_Cvar_TablePrefix 			    = CreateConVar("sm_weapons_table_prefix", 			"", 				"Prefix for database table (example: 'xyz_')");
+	g_Cvar_ChatPrefix 			    = CreateConVar("sm_weapons_chat_prefix", 			"[oyunhost.net]", 	"Prefix for chat messages");
 	g_Cvar_KnifeStatTrakMode 		= CreateConVar("sm_weapons_knife_stattrak_mode", 	"0", 				"0: All knives show the same StatTrak counter (total knife kills) 1: Each type of knife shows its own separate StatTrak counter");
-	g_Cvar_EnableFloat 			= CreateConVar("sm_weapons_enable_float", 			"1", 				"Enable/Disable weapon float options");
+	g_Cvar_EnableFloat 			    = CreateConVar("sm_weapons_enable_float", 			"1", 				"Enable/Disable weapon float options");
 	g_Cvar_EnableNameTag 			= CreateConVar("sm_weapons_enable_nametag", 		"1", 				"Enable/Disable name tag options");
 	g_Cvar_EnableStatTrak 			= CreateConVar("sm_weapons_enable_stattrak", 		"1", 				"Enable/Disable StatTrak options");
-	g_Cvar_FloatIncrementSize 		= CreateConVar("sm_weapons_float_increment_size", 	"0.05", 			"Increase/Decrease by value for weapon float");
+    g_Cvar_EnableAllSkins           = CreateConVar("sm_weapons_enable_allskins",        "1",                "Enable/Disable All Skins options");
+    g_Cvar_EnableSeed               = CreateConVar("sm_weapons_enable_seed",            "1",                "Enable/Disable Seed options");
+    g_Cvar_FloatIncrementSize 		= CreateConVar("sm_weapons_float_increment_size", 	"0.05", 			"Increase/Decrease by value for weapon float");
 	g_Cvar_EnableWeaponOverwrite 	= CreateConVar("sm_weapons_enable_overwrite", 		"1", 				"Enable/Disable players overwriting other players' weapons (picked up from the ground) by using !ws command");
-	g_Cvar_GracePeriod 			= CreateConVar("sm_weapons_grace_period", 			"0", 				"Grace period in terms of seconds counted after round start for allowing the use of !ws command. 0 means no restrictions");
+	g_Cvar_GracePeriod 			    = CreateConVar("sm_weapons_grace_period", 			"0", 				"Grace period in terms of seconds counted after round start for allowing the use of !ws command. 0 means no restrictions");
 	g_Cvar_InactiveDays 			= CreateConVar("sm_weapons_inactive_days", 			"30", 				"Number of days before a player (SteamID) is marked as inactive and his data is deleted. (0 or any negative value to disable deleting)");
 	
 	AutoExecConfig(true, "weapons");
@@ -116,7 +118,8 @@ public Action CommandWeaponSkins(int client, int args)
 
 public Action CommandSeedMenu(int client, int args)
 {
-	if (IsValidClient(client)) {
+	if (IsValidClient(client) && g_bEnableSeed)
+    {
 		int curWep = GetEntPropEnt(client, Prop_Data, "m_hActiveWeapon");
 		if (!IsValidEntity(curWep) || !g_iSkins[client][GetWeaponIndex(curWep)])
         {
@@ -135,6 +138,10 @@ public Action CommandSeedMenu(int client, int args)
 			PrintToChat(client, " %s \x02%t", g_ChatPrefix, "GracePeriod", g_iGracePeriod);
 		}
 	}
+    else
+    {
+        PrintToChat(client, "Invalid client or seed disabled.");
+    }
 	return Plugin_Handled;
 }
 
@@ -193,7 +200,16 @@ void SetWeaponProps(int client, int entity)
 		SetEntProp(entity, Prop_Send, "m_iItemIDHigh", IDHigh++);
 		SetEntProp(entity, Prop_Send, "m_nFallbackPaintKit", g_iSkins[client][index] == -1 ? GetRandomSkin(client, index) : g_iSkins[client][index]);
 		SetEntPropFloat(entity, Prop_Send, "m_flFallbackWear", !g_bEnableFloat || g_fFloatValue[client][index] == 0.0 ? 0.000001 : g_fFloatValue[client][index] == 1.0 ? 0.999999 : g_fFloatValue[client][index]);
-		SetEntProp(entity, Prop_Send, "m_nFallbackSeed", g_iWeaponSeed[client][index] == -1 ? (g_iSeedRandom[client][index] = GetRandomInt(0, 8192)) : g_iWeaponSeed[client][index]);
+		if (g_bEnableSeed && g_iWeaponSeed[client][index] != -1)
+        {
+            SetEntProp(entity, Prop_Send, "m_nFallbackSeed", g_iWeaponSeed[client][index]);
+        }
+        else
+        {
+            g_iSeedRandom[client][index] = GetRandomInt(0, 8192);
+            SetEntProp(entity, Prop_Send, "m_nFallbackSeed", g_iSeedRandom[client][index]);
+        }
+        
 		if(!IsKnife(entity))
 		{
 			if(g_bEnableStatTrak)

--- a/addons/sourcemod/scripting/weapons.sp
+++ b/addons/sourcemod/scripting/weapons.sp
@@ -60,17 +60,17 @@ public void OnPluginStart()
 	LoadTranslations("weapons.phrases");
 	
 	g_Cvar_DBConnection 			= CreateConVar("sm_weapons_db_connection", 			"storage-local", 	"Database connection name in databases.cfg to use");
-	g_Cvar_TablePrefix 			    = CreateConVar("sm_weapons_table_prefix", 			"", 				"Prefix for database table (example: 'xyz_')");
-	g_Cvar_ChatPrefix 			    = CreateConVar("sm_weapons_chat_prefix", 			"[oyunhost.net]", 	"Prefix for chat messages");
+	g_Cvar_TablePrefix 				= CreateConVar("sm_weapons_table_prefix", 			"", 				"Prefix for database table (example: 'xyz_')");
+	g_Cvar_ChatPrefix 				= CreateConVar("sm_weapons_chat_prefix", 			"[oyunhost.net]", 	"Prefix for chat messages");
 	g_Cvar_KnifeStatTrakMode 		= CreateConVar("sm_weapons_knife_stattrak_mode", 	"0", 				"0: All knives show the same StatTrak counter (total knife kills) 1: Each type of knife shows its own separate StatTrak counter");
-	g_Cvar_EnableFloat 			    = CreateConVar("sm_weapons_enable_float", 			"1", 				"Enable/Disable weapon float options");
+	g_Cvar_EnableFloat 				= CreateConVar("sm_weapons_enable_float", 			"1", 				"Enable/Disable weapon float options");
 	g_Cvar_EnableNameTag 			= CreateConVar("sm_weapons_enable_nametag", 		"1", 				"Enable/Disable name tag options");
 	g_Cvar_EnableStatTrak 			= CreateConVar("sm_weapons_enable_stattrak", 		"1", 				"Enable/Disable StatTrak options");
-    g_Cvar_EnableAllSkins           = CreateConVar("sm_weapons_enable_allskins",        "1",                "Enable/Disable All Skins options");
-    g_Cvar_EnableSeed               = CreateConVar("sm_weapons_enable_seed",            "1",                "Enable/Disable Seed options");
-    g_Cvar_FloatIncrementSize 		= CreateConVar("sm_weapons_float_increment_size", 	"0.05", 			"Increase/Decrease by value for weapon float");
+	g_Cvar_EnableAllSkins			= CreateConVar("sm_weapons_enable_allskins",		"1",				"Enable/Disable All Skins options");
+	g_Cvar_EnableSeed				= CreateConVar("sm_weapons_enable_seed",			"1",				"Enable/Disable Seed options");
+	g_Cvar_FloatIncrementSize 		= CreateConVar("sm_weapons_float_increment_size", 	"0.05", 			"Increase/Decrease by value for weapon float");
 	g_Cvar_EnableWeaponOverwrite 	= CreateConVar("sm_weapons_enable_overwrite", 		"1", 				"Enable/Disable players overwriting other players' weapons (picked up from the ground) by using !ws command");
-	g_Cvar_GracePeriod 			    = CreateConVar("sm_weapons_grace_period", 			"0", 				"Grace period in terms of seconds counted after round start for allowing the use of !ws command. 0 means no restrictions");
+	g_Cvar_GracePeriod 				= CreateConVar("sm_weapons_grace_period", 			"0", 				"Grace period in terms of seconds counted after round start for allowing the use of !ws command. 0 means no restrictions");
 	g_Cvar_InactiveDays 			= CreateConVar("sm_weapons_inactive_days", 			"30", 				"Number of days before a player (SteamID) is marked as inactive and his data is deleted. (0 or any negative value to disable deleting)");
 	
 	AutoExecConfig(true, "weapons");
@@ -119,29 +119,29 @@ public Action CommandWeaponSkins(int client, int args)
 public Action CommandSeedMenu(int client, int args)
 {
 	if (IsValidClient(client) && g_bEnableSeed)
-    {
+	{
 		int curWep = GetEntPropEnt(client, Prop_Data, "m_hActiveWeapon");
 		if (!IsValidEntity(curWep) || !g_iSkins[client][GetWeaponIndex(curWep)])
-        {
+		{
 			PrintToChat(client, " %s Please equip a skinned weapon!", g_ChatPrefix);
 			return Plugin_Handled;
 		}
-        g_iIndex[client] = GetWeaponIndex(curWep);
+		g_iIndex[client] = GetWeaponIndex(curWep);
 
 		int menuTime;
 		if((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
-        {
+		{
 			CreateSeedMenu(client).Display(client, menuTime);
 		}
-        else
-        {
+		else
+		{
 			PrintToChat(client, " %s \x02%t", g_ChatPrefix, "GracePeriod", g_iGracePeriod);
 		}
 	}
-    else
-    {
-        PrintToChat(client, "Invalid client or seed disabled.");
-    }
+	else
+	{
+		PrintToChat(client, "Invalid client or seed disabled.");
+	}
 	return Plugin_Handled;
 }
 
@@ -201,15 +201,15 @@ void SetWeaponProps(int client, int entity)
 		SetEntProp(entity, Prop_Send, "m_nFallbackPaintKit", g_iSkins[client][index] == -1 ? GetRandomSkin(client, index) : g_iSkins[client][index]);
 		SetEntPropFloat(entity, Prop_Send, "m_flFallbackWear", !g_bEnableFloat || g_fFloatValue[client][index] == 0.0 ? 0.000001 : g_fFloatValue[client][index] == 1.0 ? 0.999999 : g_fFloatValue[client][index]);
 		if (g_bEnableSeed && g_iWeaponSeed[client][index] != -1)
-        {
-            SetEntProp(entity, Prop_Send, "m_nFallbackSeed", g_iWeaponSeed[client][index]);
-        }
-        else
-        {
-            g_iSeedRandom[client][index] = GetRandomInt(0, 8192);
-            SetEntProp(entity, Prop_Send, "m_nFallbackSeed", g_iSeedRandom[client][index]);
-        }
-        
+		{
+			SetEntProp(entity, Prop_Send, "m_nFallbackSeed", g_iWeaponSeed[client][index]);
+		}
+		else
+		{
+			g_iSeedRandom[client][index] = GetRandomInt(0, 8192);
+			SetEntProp(entity, Prop_Send, "m_nFallbackSeed", g_iSeedRandom[client][index]);
+		}
+		
 		if(!IsKnife(entity))
 		{
 			if(g_bEnableStatTrak)

--- a/addons/sourcemod/scripting/weapons/database.sp
+++ b/addons/sourcemod/scripting/weapons/database.sp
@@ -577,8 +577,6 @@ public void T_SeedColumnCallback(Database database, DBResultSet results, const c
 		
 		//SQL_EscapeString(db, createQuery, createQuery, sizeof(createQuery));
 		db.Driver.GetIdentifier(dbIdentifier, sizeof(dbIdentifier));
-		bool mysql = StrEqual(dbIdentifier, "mysql");
-
 		db.Query(T_SeedConfirmationCallback, createQuery, mysql, DBPrio_High);
 	}
 	else

--- a/addons/sourcemod/scripting/weapons/database.sp
+++ b/addons/sourcemod/scripting/weapons/database.sp
@@ -50,6 +50,7 @@ public void T_GetPlayerDataCallback(Database database, DBResultSet results, cons
 				g_iStatTrakCount[clientIndex][i] = 0;
 				g_NameTag[clientIndex][i] = "";
 				g_fFloatValue[clientIndex][i] = 0.0;
+				g_iWeaponSeed[clientIndex][i] = -1;
 			}
 			g_iKnife[clientIndex] = 0;
 		}
@@ -57,13 +58,14 @@ public void T_GetPlayerDataCallback(Database database, DBResultSet results, cons
 		{
 			if(results.FetchRow())
 			{
-				for(int i = 2, j = 0; j < sizeof(g_WeaponClasses); i += 5, j++) 
+				for(int i = 2, j = 0; j < sizeof(g_WeaponClasses); i += 6, j++) 
 				{
 					g_iSkins[clientIndex][j] = results.FetchInt(i);
 					g_fFloatValue[clientIndex][j] = results.FetchFloat(i + 1);
 					g_iStatTrak[clientIndex][j] = results.FetchInt(i + 2);
 					g_iStatTrakCount[clientIndex][j] = results.FetchInt(i + 3);
 					results.FetchString(i + 4, g_NameTag[clientIndex][j], 128);
+					g_iWeaponSeed[clientIndex][j] = results.FetchInt(i + 5);
 				}
 				g_iKnife[clientIndex] = results.FetchInt(1);
 			}
@@ -158,254 +160,302 @@ public void SQLConnectCallback(Database database, const char[] error, any data)
 				awp_trak int(1) NOT NULL DEFAULT '0', 							\
 				awp_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				awp_tag varchar(256) NOT NULL DEFAULT '', 						\
+				awp_seed int(10) NOT NULL DEFAULT '-1',							\
 				ak47 int(4) NOT NULL DEFAULT '0', 								\
 				ak47_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				ak47_trak int(1) NOT NULL DEFAULT '0', 							\
 				ak47_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				ak47_tag varchar(256) NOT NULL DEFAULT '', 						\
+				ak47_seed int(10) NOT NULL DEFAULT '-1',						\
 				m4a1 int(4) NOT NULL DEFAULT '0', 								\
 				m4a1_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				m4a1_trak int(1) NOT NULL DEFAULT '0', 							\
 				m4a1_trak_count int(10) NOT NULL DEFAULT '0', 					\
-				m4a1_tag varchar(256) NOT NULL DEFAULT '', ", g_TablePrefix);
+				m4a1_tag varchar(256) NOT NULL DEFAULT '',						\
+				m4a1_seed int(10) NOT NULL DEFAULT '-1', ", g_TablePrefix);
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				m4a1_silencer int(4) NOT NULL DEFAULT '0', 						\
 				m4a1_silencer_float decimal(3,2) NOT NULL DEFAULT '0.0', 		\
 				m4a1_silencer_trak int(1) NOT NULL DEFAULT '0', 				\
 				m4a1_silencer_trak_count int(10) NOT NULL DEFAULT '0', 			\
 				m4a1_silencer_tag varchar(256) NOT NULL DEFAULT '', 			\
+				m4a1_silencer_seed int(10) NOT NULL DEFAULT '-1',				\
 				deagle int(4) NOT NULL DEFAULT '0', 							\
 				deagle_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				deagle_trak int(1) NOT NULL DEFAULT '0', 						\
 				deagle_trak_count int(10) NOT NULL DEFAULT '0', 				\
 				deagle_tag varchar(256) NOT NULL DEFAULT '', 					\
+				deagle_seed int(10) NOT NULL DEFAULT '-1',						\
 				usp_silencer int(4) NOT NULL DEFAULT '0', 						\
 				usp_silencer_float decimal(3,2) NOT NULL DEFAULT '0.0', 		\
 				usp_silencer_trak int(1) NOT NULL DEFAULT '0', 					\
 				usp_silencer_trak_count int(10) NOT NULL DEFAULT '0', 			\
 				usp_silencer_tag varchar(256) NOT NULL DEFAULT '', 				\
+				usp_silencer_seed int(10) NOT NULL DEFAULT '-1',				\
 				hkp2000 int(4) NOT NULL DEFAULT '0', 							\
 				hkp2000_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				hkp2000_trak int(1) NOT NULL DEFAULT '0', ");
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				hkp2000_trak_count int(10) NOT NULL DEFAULT '0', 				\
 				hkp2000_tag varchar(256) NOT NULL DEFAULT '', 					\
+				hkp2000_seed int(10) NOT NULL DEFAULT '-1',						\
 				glock int(4) NOT NULL DEFAULT '0', 								\
 				glock_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				glock_trak int(1) NOT NULL DEFAULT '0', 						\
 				glock_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				glock_tag varchar(256) NOT NULL DEFAULT '', 					\
+				glock_seed int(10) NOT NULL DEFAULT '-1',						\
 				elite int(4) NOT NULL DEFAULT '0', 								\
 				elite_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				elite_trak int(1) NOT NULL DEFAULT '0', 						\
 				elite_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				elite_tag varchar(256) NOT NULL DEFAULT '', 					\
+				elite_seed int(10) NOT NULL DEFAULT '-1',						\
 				p250 int(4) NOT NULL DEFAULT '0', 								\
 				p250_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				p250_trak int(1) NOT NULL DEFAULT '0', 							\
 				p250_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				p250_tag varchar(256) NOT NULL DEFAULT '', 						\
+				p250_seed int(10) NOT NULL DEFAULT '-1',						\
 				cz75a int(4) NOT NULL DEFAULT '0', ");
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				cz75a_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				cz75a_trak int(1) NOT NULL DEFAULT '0', 						\
 				cz75a_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				cz75a_tag varchar(256) NOT NULL DEFAULT '', 					\
+				cz75a_seed int(10) NOT NULL DEFAULT '-1',						\
 				fiveseven int(4) NOT NULL DEFAULT '0', 							\
 				fiveseven_float decimal(3,2) NOT NULL DEFAULT '0.0', 			\
 				fiveseven_trak int(1) NOT NULL DEFAULT '0', 					\
 				fiveseven_trak_count int(10) NOT NULL DEFAULT '0', 				\
 				fiveseven_tag varchar(256) NOT NULL DEFAULT '', 				\
+				fiveseven_seed int(10) NOT NULL DEFAULT '-1',					\
 				tec9 int(4) NOT NULL DEFAULT '0', 								\
 				tec9_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				tec9_trak int(1) NOT NULL DEFAULT '0', 							\
 				tec9_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				tec9_tag varchar(256) NOT NULL DEFAULT '', 						\
+				tec9_seed int(10) NOT NULL DEFAULT '-1',						\
 				revolver int(4) NOT NULL DEFAULT '0', 							\
 				revolver_float decimal(3,2) NOT NULL DEFAULT '0.0', 			\
 				revolver_trak int(1) NOT NULL DEFAULT '0', 						\
 				revolver_trak_count int(10) NOT NULL DEFAULT '0', ");
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				revolver_tag varchar(256) NOT NULL DEFAULT '', 					\
+				revolver_seed int(10) NOT NULL DEFAULT '-1',					\
 				nova int(4) NOT NULL DEFAULT '0', 								\
 				nova_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				nova_trak int(1) NOT NULL DEFAULT '0', 							\
 				nova_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				nova_tag varchar(256) NOT NULL DEFAULT '', 						\
+				nova_seed int(10) NOT NULL DEFAULT '-1',						\
 				xm1014 int(4) NOT NULL DEFAULT '0', 							\
 				xm1014_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				xm1014_trak int(1) NOT NULL DEFAULT '0', 						\
 				xm1014_trak_count int(10) NOT NULL DEFAULT '0', 				\
 				xm1014_tag varchar(256) NOT NULL DEFAULT '', 					\
+				xm1014_seed int(10) NOT NULL DEFAULT '-1',						\
 				mag7 int(4) NOT NULL DEFAULT '0', 								\
 				mag7_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				mag7_trak int(1) NOT NULL DEFAULT '0', 							\
 				mag7_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				mag7_tag varchar(256) NOT NULL DEFAULT '', 						\
+				mag7_seed int(10) NOT NULL DEFAULT '-1',						\
 				sawedoff int(4) NOT NULL DEFAULT '0', 							\
 				sawedoff_float decimal(3,2) NOT NULL DEFAULT '0.0', ");
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				sawedoff_trak int(1) NOT NULL DEFAULT '0', 						\
 				sawedoff_trak_count int(10) NOT NULL DEFAULT '0', 				\
 				sawedoff_tag varchar(256) NOT NULL DEFAULT '', 					\
+				sawedoff_seed int(10) NOT NULL DEFAULT '-1',					\
 				m249 int(4) NOT NULL DEFAULT '0', 								\
 				m249_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				m249_trak int(1) NOT NULL DEFAULT '0', 							\
 				m249_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				m249_tag varchar(256) NOT NULL DEFAULT '', 						\
+				m249_seed int(10) NOT NULL DEFAULT '-1',						\
 				negev int(4) NOT NULL DEFAULT '0', 								\
 				negev_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				negev_trak int(1) NOT NULL DEFAULT '0', 						\
 				negev_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				negev_tag varchar(256) NOT NULL DEFAULT '', 					\
+				negev_seed int(10) NOT NULL DEFAULT '-1',						\
 				mp9 int(4) NOT NULL DEFAULT '0', 								\
 				mp9_float decimal(3,2) NOT NULL DEFAULT '0.0', 					\
 				mp9_trak int(1) NOT NULL DEFAULT '0', 							\
 				mp9_trak_count int(10) NOT NULL DEFAULT '0', 					\
-				mp9_tag varchar(256) NOT NULL DEFAULT '', ");
+				mp9_tag varchar(256) NOT NULL DEFAULT '',						\
+				mp9_seed int(10) NOT NULL DEFAULT '-1', ");
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				mac10 int(4) NOT NULL DEFAULT '0', 								\
 				mac10_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				mac10_trak int(1) NOT NULL DEFAULT '0', 						\
 				mac10_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				mac10_tag varchar(256) NOT NULL DEFAULT '', 					\
+				mac10_seed int(10) NOT NULL DEFAULT '-1',						\
 				mp7 int(4) NOT NULL DEFAULT '0', 								\
 				mp7_float decimal(3,2) NOT NULL DEFAULT '0.0', 					\
 				mp7_trak int(1) NOT NULL DEFAULT '0', 							\
 				mp7_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				mp7_tag varchar(256) NOT NULL DEFAULT '', 						\
+				mp7_seed int(10) NOT NULL DEFAULT '-1',							\
 				ump45 int(4) NOT NULL DEFAULT '0', 								\
 				ump45_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				ump45_trak int(1) NOT NULL DEFAULT '0', 						\
 				ump45_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				ump45_tag varchar(256) NOT NULL DEFAULT '', 					\
+				ump45_seed int(10) NOT NULL DEFAULT '-1',						\
 				p90 int(4) NOT NULL DEFAULT '0', 								\
 				p90_float decimal(3,2) NOT NULL DEFAULT '0.0', 					\
 				p90_trak int(1) NOT NULL DEFAULT '0', ");
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				p90_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				p90_tag varchar(256) NOT NULL DEFAULT '', 						\
+				p90_seed int(10) NOT NULL DEFAULT '-1',							\
 				bizon int(4) NOT NULL DEFAULT '0', 								\
 				bizon_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				bizon_trak int(1) NOT NULL DEFAULT '0', 						\
 				bizon_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				bizon_tag varchar(256) NOT NULL DEFAULT '', 					\
+				bizon_seed int(10) NOT NULL DEFAULT '-1',						\
 				famas int(4) NOT NULL DEFAULT '0', 								\
 				famas_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				famas_trak int(1) NOT NULL DEFAULT '0', 						\
 				famas_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				famas_tag varchar(256) NOT NULL DEFAULT '', 					\
+				famas_seed int(10) NOT NULL DEFAULT '-1',						\
 				galilar int(4) NOT NULL DEFAULT '0', 							\
 				galilar_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				galilar_trak int(1) NOT NULL DEFAULT '0', 						\
 				galilar_trak_count int(10) NOT NULL DEFAULT '0', 				\
 				galilar_tag varchar(256) NOT NULL DEFAULT '', 					\
+				galilar_seed int(10) NOT NULL DEFAULT '-1',						\
 				ssg08 int(4) NOT NULL DEFAULT '0', ");
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				ssg08_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				ssg08_trak int(1) NOT NULL DEFAULT '0', 						\
 				ssg08_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				ssg08_tag varchar(256) NOT NULL DEFAULT '', 					\
+				ssg08_seed int(10) NOT NULL DEFAULT '-1',						\
 				aug int(4) NOT NULL DEFAULT '0', 								\
 				aug_float decimal(3,2) NOT NULL DEFAULT '0.0', 					\
 				aug_trak int(1) NOT NULL DEFAULT '0', 							\
 				aug_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				aug_tag varchar(256) NOT NULL DEFAULT '', 						\
+				aug_seed int(10) NOT NULL DEFAULT '-1',							\
 				sg556 int(4) NOT NULL DEFAULT '0', 								\
 				sg556_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				sg556_trak int(1) NOT NULL DEFAULT '0', 						\
 				sg556_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				sg556_tag varchar(256) NOT NULL DEFAULT '', 					\
+				sg556_seed int(10) NOT NULL DEFAULT '-1',						\
 				scar20 int(4) NOT NULL DEFAULT '0', 							\
 				scar20_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				scar20_trak int(1) NOT NULL DEFAULT '0', 						\
 				scar20_trak_count int(10) NOT NULL DEFAULT '0', ");
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				scar20_tag varchar(256) NOT NULL DEFAULT '', 					\
+				scar20_seed int(10) NOT NULL DEFAULT '-1',						\
 				g3sg1 int(4) NOT NULL DEFAULT '0', 								\
 				g3sg1_float decimal(3,2) NOT NULL DEFAULT '0.0', 				\
 				g3sg1_trak int(1) NOT NULL DEFAULT '0', 						\
 				g3sg1_trak_count int(10) NOT NULL DEFAULT '0', 					\
 				g3sg1_tag varchar(256) NOT NULL DEFAULT '', 					\
+				g3sg1_seed int(10) NOT NULL DEFAULT '-1',						\
 				knife_karambit int(4) NOT NULL DEFAULT '0', 					\
 				knife_karambit_float decimal(3,2) NOT NULL DEFAULT '0.0', 		\
 				knife_karambit_trak int(1) NOT NULL DEFAULT '0', 				\
 				knife_karambit_trak_count int(10) NOT NULL DEFAULT '0', 		\
 				knife_karambit_tag varchar(256) NOT NULL DEFAULT '', 			\
+				knife_karambit_seed int(10) NOT NULL DEFAULT '-1',				\
 				knife_m9_bayonet int(4) NOT NULL DEFAULT '0', 					\
 				knife_m9_bayonet_float decimal(3,2) NOT NULL DEFAULT '0.0', 	\
 				knife_m9_bayonet_trak int(1) NOT NULL DEFAULT '0', 				\
 				knife_m9_bayonet_trak_count int(10) NOT NULL DEFAULT '0', 		\
 				knife_m9_bayonet_tag varchar(256) NOT NULL DEFAULT '', 			\
+				knife_m9_bayonet_seed int(10) NOT NULL DEFAULT '-1',			\
 				bayonet int(4) NOT NULL DEFAULT '0', 							\
 				bayonet_float decimal(3,2) NOT NULL DEFAULT '0.0', ");
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				bayonet_trak int(1) NOT NULL DEFAULT '0', 						\
 				bayonet_trak_count int(10) NOT NULL DEFAULT '0', 				\
 				bayonet_tag varchar(256) NOT NULL DEFAULT '', 					\
+				bayonet_seed int(10) NOT NULL DEFAULT '-1',						\
 				knife_survival_bowie int(4) NOT NULL DEFAULT '0', 				\
 				knife_survival_bowie_float decimal(3,2) NOT NULL DEFAULT '0.0', \
 				knife_survival_bowie_trak int(1) NOT NULL DEFAULT '0', 			\
 				knife_survival_bowie_trak_count int(10) NOT NULL DEFAULT '0', 	\
 				knife_survival_bowie_tag varchar(256) NOT NULL DEFAULT '', 		\
+				knife_survival_bowie_seed int(10) NOT NULL DEFAULT '-1',		\
 				knife_butterfly int(4) NOT NULL DEFAULT '0', 					\
 				knife_butterfly_float decimal(3,2) NOT NULL DEFAULT '0.0', 		\
 				knife_butterfly_trak int(1) NOT NULL DEFAULT '0', 				\
 				knife_butterfly_trak_count int(10) NOT NULL DEFAULT '0', 		\
 				knife_butterfly_tag varchar(256) NOT NULL DEFAULT '', 			\
+				knife_butterfly_seed int(10) NOT NULL DEFAULT '-1',				\
 				knife_flip int(4) NOT NULL DEFAULT '0', 						\
 				knife_flip_float decimal(3,2) NOT NULL DEFAULT '0.0', 			\
 				knife_flip_trak int(1) NOT NULL DEFAULT '0', 					\
 				knife_flip_trak_count int(10) NOT NULL DEFAULT '0', 			\
-				knife_flip_tag varchar(256) NOT NULL DEFAULT '', ");
+				knife_flip_tag varchar(256) NOT NULL DEFAULT '',				\
+				knife_flip_seed int(10) NOT NULL DEFAULT '-1', ");
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				knife_push int(4) NOT NULL DEFAULT '0', 						\
 				knife_push_float decimal(3,2) NOT NULL DEFAULT '0.0', 			\
 				knife_push_trak int(1) NOT NULL DEFAULT '0', 					\
 				knife_push_trak_count int(10) NOT NULL DEFAULT '0', 			\
 				knife_push_tag varchar(256) NOT NULL DEFAULT '', 				\
+				knife_push_seed int(10) NOT NULL DEFAULT '-1',					\
 				knife_tactical int(4) NOT NULL DEFAULT '0', 					\
 				knife_tactical_float decimal(3,2) NOT NULL DEFAULT '0.0', 		\
 				knife_tactical_trak int(1) NOT NULL DEFAULT '0', 				\
 				knife_tactical_trak_count int(10) NOT NULL DEFAULT '0', 		\
 				knife_tactical_tag varchar(256) NOT NULL DEFAULT '', 			\
+				knife_tactical_seed int(10) NOT NULL DEFAULT '-1',				\
 				knife_falchion int(4) NOT NULL DEFAULT '0', 					\
 				knife_falchion_float decimal(3,2) NOT NULL DEFAULT '0.0', 		\
 				knife_falchion_trak int(1) NOT NULL DEFAULT '0', 				\
 				knife_falchion_trak_count int(10) NOT NULL DEFAULT '0', 		\
 				knife_falchion_tag varchar(256) NOT NULL DEFAULT '', 			\
+				knife_falchion_seed int(10) NOT NULL DEFAULT '-1',				\
 				knife_gut int(4) NOT NULL DEFAULT '0', 							\
 				knife_gut_float decimal(3,2) NOT NULL DEFAULT '0.0', 			\
 				knife_gut_trak int(1) NOT NULL DEFAULT '0', ");
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				knife_gut_trak_count int(10) NOT NULL DEFAULT '0', 				\
 				knife_gut_tag varchar(256) NOT NULL DEFAULT '', 				\
+				knife_gut_seed int(10) NOT NULL DEFAULT '-1',					\
 				knife_ursus int(4) NOT NULL DEFAULT '0', 						\
 				knife_ursus_float decimal(3,2) NOT NULL DEFAULT '0.0', 			\
 				knife_ursus_trak int(1) NOT NULL DEFAULT '0', 					\
 				knife_ursus_trak_count int(10) NOT NULL DEFAULT '0', 			\
 				knife_ursus_tag varchar(256) NOT NULL DEFAULT '', 				\
+				knife_ursus_seed int(10) NOT NULL DEFAULT '-1',					\
 				knife_gypsy_jackknife int(4) NOT NULL DEFAULT '0', 				\
 				knife_gypsy_jackknife_float decimal(3,2) NOT NULL DEFAULT '0.0',\
 				knife_gypsy_jackknife_trak int(1) NOT NULL DEFAULT '0', 		\
 				knife_gypsy_jackknife_trak_count int(10) NOT NULL DEFAULT '0', 	\
 				knife_gypsy_jackknife_tag varchar(256) NOT NULL DEFAULT '', 	\
+				knife_gypsy_jackknife_seed int(10) NOT NULL DEFAULT '-1',		\
 				knife_stiletto int(4) NOT NULL DEFAULT '0', 					\
 				knife_stiletto_float decimal(3,2) NOT NULL DEFAULT '0.0', 		\
 				knife_stiletto_trak int(1) NOT NULL DEFAULT '0', 				\
 				knife_stiletto_trak_count int(10) NOT NULL DEFAULT '0', 		\
 				knife_stiletto_tag varchar(256) NOT NULL DEFAULT '', 			\
+				knife_stiletto_seed int(10) NOT NULL DEFAULT '-1',				\
 				knife_widowmaker int(4) NOT NULL DEFAULT '0', ");
 		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "	\
 				knife_widowmaker_float decimal(3,2) NOT NULL DEFAULT '0.0', 	\
 				knife_widowmaker_trak int(1) NOT NULL DEFAULT '0', 				\
 				knife_widowmaker_trak_count int(10) NOT NULL DEFAULT '0', 		\
-				knife_widowmaker_tag varchar(256) NOT NULL DEFAULT '', 			\
-				mp5sd int(4) NOT NULL DEFAULT '0', 								\
+				knife_widowmaker_tag varchar(256) NOT NULL DEFAULT '',			\
+				knife_widowmaker_seed int(10) NOT NULL DEFAULT '-1',            \
+                mp5sd int(4) NOT NULL DEFAULT '0', 								\
 				mp5sd_float decimal(3,2) NOT NULL DEFAULT '0.0',				\
 				mp5sd_trak int(1) NOT NULL DEFAULT '0', 						\
 				mp5sd_trak_count int(10) NOT NULL DEFAULT '0', 					\
-				mp5sd_tag varchar(256) NOT NULL DEFAULT '')");
+				mp5sd_tag varchar(256) NOT NULL DEFAULT '',                     \
+                mp5sd_seed int(10) NOT NULL DEFAULT '-1')");
 		
 		db.Driver.GetIdentifier(dbIdentifier, sizeof(dbIdentifier));
 		bool mysql = StrEqual(dbIdentifier, "mysql");
@@ -430,8 +480,10 @@ public void T_CreateMainTableCallback(Database database, DBResultSet results, co
 		AddWeaponColumns("knife_gypsy_jackknife");
 		AddWeaponColumns("knife_stiletto");
 		AddWeaponColumns("knife_widowmaker");
-		AddWeaponColumns("mp5sd");
+        AddWeaponColumns("mp5sd");
 		
+		addSeedColumns();
+
 		char createQuery[512];
 		Format(createQuery, sizeof(createQuery), "			\
 			CREATE TABLE %sweapons_timestamps ( 			\
@@ -444,6 +496,103 @@ public void T_CreateMainTableCallback(Database database, DBResultSet results, co
 		}
 		
 		db.Query(T_CreateTimestampTableCallback, createQuery, mysql, DBPrio_High);
+	}
+}
+
+void addSeedColumns()
+{
+	char createQuery[1024];
+	char dbIdentifier[10];
+	FormatEx(createQuery, sizeof(createQuery), "SELECT awp_seed FROM %sweapons", g_TablePrefix);
+
+	db.Driver.GetIdentifier(dbIdentifier, sizeof(dbIdentifier));
+	bool mysql = StrEqual(dbIdentifier, "mysql");
+	
+	SQL_EscapeString(db, createQuery, createQuery, sizeof(createQuery));
+
+	db.Query(T_SeedColumnCallback, createQuery, mysql, DBPrio_High);
+}
+
+public void T_SeedColumnCallback(Database database, DBResultSet results, const char[] error, bool mysql)
+{
+	if (results == null) {
+		LogMessage("%s Attempting to create seed tables", (mysql ? "MySQL" : "SQLite"));
+
+		char createQuery[20480];
+		char dbIdentifier[10];
+		
+		int index = 0;
+		
+		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "											\
+			ALTER TABLE %sweapons																						\
+				ADD COLUMN awp_seed int(10) NOT NULL DEFAULT '-1' AFTER awp_tag,										\
+				ADD COLUMN ak47_seed int(10) NOT NULL DEFAULT '-1' AFTER ak47_tag,										\
+				ADD COLUMN m4a1_seed int(10) NOT NULL DEFAULT '-1' AFTER m4a1_tag,										\
+				ADD COLUMN m4a1_silencer_seed int(10) NOT NULL DEFAULT '-1' AFTER m4a1_silencer_tag,					\
+				ADD COLUMN deagle_seed int(10) NOT NULL DEFAULT '-1' AFTER deagle_tag,									\
+				ADD COLUMN usp_silencer_seed int(10) NOT NULL DEFAULT '-1' AFTER usp_silencer_tag,						\
+				ADD COLUMN hkp2000_seed int(10) NOT NULL DEFAULT '-1' AFTER hkp2000_tag,								\
+				ADD COLUMN glock_seed int(10) NOT NULL DEFAULT '-1' AFTER glock_tag,									\
+				ADD COLUMN elite_seed int(10) NOT NULL DEFAULT '-1' AFTER elite_tag,									\
+				ADD COLUMN p250_seed int(10) NOT NULL DEFAULT '-1' AFTER p250_tag,										\
+				ADD COLUMN cz75a_seed int(10) NOT NULL DEFAULT '-1' AFTER cz75a_tag,									\
+				ADD COLUMN fiveseven_seed int(10) NOT NULL DEFAULT '-1' AFTER fiveseven_tag,							\
+				ADD COLUMN tec9_seed int(10) NOT NULL DEFAULT '-1' AFTER tec9_tag,										\
+				ADD COLUMN revolver_seed int(10) NOT NULL DEFAULT '-1' AFTER revolver_tag,								\
+				ADD COLUMN nova_seed int(10) NOT NULL DEFAULT '-1' AFTER nova_tag,										\
+				ADD COLUMN xm1014_seed int(10) NOT NULL DEFAULT '-1' AFTER xm1014_tag,									\
+				ADD COLUMN mag7_seed int(10) NOT NULL DEFAULT '-1' AFTER mag7_tag,										\
+				ADD COLUMN sawedoff_seed int(10) NOT NULL DEFAULT '-1' AFTER sawedoff_tag,								\
+				ADD COLUMN m249_seed int(10) NOT NULL DEFAULT '-1' AFTER m249_tag,										\
+				ADD COLUMN negev_seed int(10) NOT NULL DEFAULT '-1' AFTER negev_tag,									\
+				ADD COLUMN mp9_seed int(10) NOT NULL DEFAULT '-1' AFTER mp9_tag, ", g_TablePrefix);
+		index += FormatEx(createQuery[index], sizeof(createQuery) - index, "											\
+				ADD COLUMN mac10_seed int(10) NOT NULL DEFAULT '-1' AFTER mac10_tag,									\
+				ADD COLUMN mp7_seed int(10) NOT NULL DEFAULT '-1' AFTER mp7_tag,										\
+				ADD COLUMN ump45_seed int(10) NOT NULL DEFAULT '-1' AFTER ump45_tag,									\
+				ADD COLUMN p90_seed int(10) NOT NULL DEFAULT '-1' AFTER p90_tag,										\
+				ADD COLUMN bizon_seed int(10) NOT NULL DEFAULT '-1' AFTER bizon_tag,									\
+				ADD COLUMN famas_seed int(10) NOT NULL DEFAULT '-1' AFTER famas_tag,									\
+				ADD COLUMN galilar_seed int(10) NOT NULL DEFAULT '-1' AFTER galilar_tag,								\
+				ADD COLUMN ssg08_seed int(10) NOT NULL DEFAULT '-1' AFTER ssg08_tag,									\
+				ADD COLUMN aug_seed int(10) NOT NULL DEFAULT '-1' AFTER aug_tag,										\
+				ADD COLUMN sg556_seed int(10) NOT NULL DEFAULT '-1' AFTER sg556_tag,									\
+				ADD COLUMN scar20_seed int(10) NOT NULL DEFAULT '-1' AFTER scar20_tag,									\
+				ADD COLUMN g3sg1_seed int(10) NOT NULL DEFAULT '-1' AFTER g3sg1_tag,									\
+				ADD COLUMN knife_karambit_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_karambit_tag,					\
+				ADD COLUMN knife_m9_bayonet_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_m9_bayonet_tag,				\
+				ADD COLUMN bayonet_seed int(10) NOT NULL DEFAULT '-1' AFTER bayonet_tag,								\
+				ADD COLUMN knife_survival_bowie_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_survival_bowie_tag,		\
+				ADD COLUMN knife_butterfly_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_butterfly_tag,				\
+				ADD COLUMN knife_flip_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_flip_tag,							\
+				ADD COLUMN knife_push_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_push_tag,							\
+				ADD COLUMN knife_tactical_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_tactical_tag,					\
+				ADD COLUMN knife_falchion_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_falchion_tag,					\
+				ADD COLUMN knife_gut_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_gut_tag,							\
+				ADD COLUMN knife_ursus_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_ursus_tag,						\
+				ADD COLUMN knife_gypsy_jackknife_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_gypsy_jackknife_tag,	\
+				ADD COLUMN knife_stiletto_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_stiletto_tag,					\
+				ADD COLUMN knife_widowmaker_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_widowmaker_tag,              \
+                ADD COLUMN mp5sd_seed int(10) NOT NULL DEFAULT '-1' AFTER mp5sd_tag");
+		
+		//SQL_EscapeString(db, createQuery, createQuery, sizeof(createQuery));
+		db.Driver.GetIdentifier(dbIdentifier, sizeof(dbIdentifier));
+		bool mysql = StrEqual(dbIdentifier, "mysql");
+
+		db.Query(T_SeedConfirmationCallback, createQuery, mysql, DBPrio_High);
+	}
+	else
+	{
+		LogMessage("%s Seed tables already exist", (mysql ? "MySQL" : "SQLite"));
+	}
+}
+
+public void T_SeedConfirmationCallback(Database database, DBResultSet results, const char[] error, bool mysql)
+{
+	if (results == null) {
+		LogMessage("Null Results: %s", error);
+	} else {
+		LogMessage("Successfully Added Columns");
 	}
 }
 
@@ -462,6 +611,8 @@ void AddWeaponColumns(const char[] weapon)
 	Format(query, sizeof(query), "ALTER TABLE %sweapons ADD %s_trak_count int(10) NOT NULL DEFAULT '0'", g_TablePrefix, weapon);
 	SQL_FastQuery(db, query);
 	Format(query, sizeof(query), "ALTER TABLE %sweapons ADD %s_tag varchar(256) NOT NULL DEFAULT ''", g_TablePrefix, weapon);
+	SQL_FastQuery(db, query);
+    Format(query, sizeof(query), "ALTER TABLE %sweapons ADD %s_seed int(10) NOT NULL DEFAULT '-1'", g_TablePrefix, weapon);
 	SQL_FastQuery(db, query);
 	
 	SQL_UnlockDatabase(db);

--- a/addons/sourcemod/scripting/weapons/database.sp
+++ b/addons/sourcemod/scripting/weapons/database.sp
@@ -449,13 +449,13 @@ public void SQLConnectCallback(Database database, const char[] error, any data)
 				knife_widowmaker_trak int(1) NOT NULL DEFAULT '0', 				\
 				knife_widowmaker_trak_count int(10) NOT NULL DEFAULT '0', 		\
 				knife_widowmaker_tag varchar(256) NOT NULL DEFAULT '',			\
-				knife_widowmaker_seed int(10) NOT NULL DEFAULT '-1',            \
-                mp5sd int(4) NOT NULL DEFAULT '0', 								\
+				knife_widowmaker_seed int(10) NOT NULL DEFAULT '-1',			\
+				mp5sd int(4) NOT NULL DEFAULT '0', 								\
 				mp5sd_float decimal(3,2) NOT NULL DEFAULT '0.0',				\
 				mp5sd_trak int(1) NOT NULL DEFAULT '0', 						\
 				mp5sd_trak_count int(10) NOT NULL DEFAULT '0', 					\
-				mp5sd_tag varchar(256) NOT NULL DEFAULT '',                     \
-                mp5sd_seed int(10) NOT NULL DEFAULT '-1')");
+				mp5sd_tag varchar(256) NOT NULL DEFAULT '',					 \
+				mp5sd_seed int(10) NOT NULL DEFAULT '-1')");
 		
 		db.Driver.GetIdentifier(dbIdentifier, sizeof(dbIdentifier));
 		bool mysql = StrEqual(dbIdentifier, "mysql");
@@ -480,7 +480,7 @@ public void T_CreateMainTableCallback(Database database, DBResultSet results, co
 		AddWeaponColumns("knife_gypsy_jackknife");
 		AddWeaponColumns("knife_stiletto");
 		AddWeaponColumns("knife_widowmaker");
-        AddWeaponColumns("mp5sd");
+		AddWeaponColumns("mp5sd");
 		
 		addSeedColumns();
 
@@ -572,8 +572,8 @@ public void T_SeedColumnCallback(Database database, DBResultSet results, const c
 				ADD COLUMN knife_ursus_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_ursus_tag,						\
 				ADD COLUMN knife_gypsy_jackknife_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_gypsy_jackknife_tag,	\
 				ADD COLUMN knife_stiletto_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_stiletto_tag,					\
-				ADD COLUMN knife_widowmaker_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_widowmaker_tag,              \
-                ADD COLUMN mp5sd_seed int(10) NOT NULL DEFAULT '-1' AFTER mp5sd_tag");
+				ADD COLUMN knife_widowmaker_seed int(10) NOT NULL DEFAULT '-1' AFTER knife_widowmaker_tag,			  \
+				ADD COLUMN mp5sd_seed int(10) NOT NULL DEFAULT '-1' AFTER mp5sd_tag");
 		
 		//SQL_EscapeString(db, createQuery, createQuery, sizeof(createQuery));
 		db.Driver.GetIdentifier(dbIdentifier, sizeof(dbIdentifier));
@@ -610,7 +610,7 @@ void AddWeaponColumns(const char[] weapon)
 	SQL_FastQuery(db, query);
 	Format(query, sizeof(query), "ALTER TABLE %sweapons ADD %s_tag varchar(256) NOT NULL DEFAULT ''", g_TablePrefix, weapon);
 	SQL_FastQuery(db, query);
-    Format(query, sizeof(query), "ALTER TABLE %sweapons ADD %s_seed int(10) NOT NULL DEFAULT '-1'", g_TablePrefix, weapon);
+	Format(query, sizeof(query), "ALTER TABLE %sweapons ADD %s_seed int(10) NOT NULL DEFAULT '-1'", g_TablePrefix, weapon);
 	SQL_FastQuery(db, query);
 	
 	SQL_UnlockDatabase(db);

--- a/addons/sourcemod/scripting/weapons/forwards.sp
+++ b/addons/sourcemod/scripting/weapons/forwards.sp
@@ -66,6 +66,11 @@ public void OnClientPutInServer(int client)
 		g_iIndex[client] = 0;
 		g_FloatTimer[client] = INVALID_HANDLE;
 		g_bWaitingForNametag[client] = false;
+		g_bWaitingForSeed[client] = false;
+		for (int i = 0; i < sizeof(g_WeaponClasses); i++)
+        {
+			g_iSeedRandom[client][i] = 0;
+		}
 		HookPlayer(client);
 	}
 }

--- a/addons/sourcemod/scripting/weapons/forwards.sp
+++ b/addons/sourcemod/scripting/weapons/forwards.sp
@@ -43,6 +43,8 @@ public void OnConfigsExecuted()
 	g_bEnableFloat = g_Cvar_EnableFloat.BoolValue;
 	g_bEnableNameTag = g_Cvar_EnableNameTag.BoolValue;
 	g_bEnableStatTrak = g_Cvar_EnableStatTrak.BoolValue;
+    g_bEnableAllSkins = g_Cvar_EnableAllSkins.BoolValue;
+    g_bEnableSeed = g_Cvar_EnableSeed.BoolValue;
 	g_fFloatIncrementSize = g_Cvar_FloatIncrementSize.FloatValue;
 	g_iFloatIncrementPercentage = RoundFloat(g_fFloatIncrementSize * 100.0);
 	g_bOverwriteEnabled = g_Cvar_EnableWeaponOverwrite.BoolValue;

--- a/addons/sourcemod/scripting/weapons/forwards.sp
+++ b/addons/sourcemod/scripting/weapons/forwards.sp
@@ -43,8 +43,8 @@ public void OnConfigsExecuted()
 	g_bEnableFloat = g_Cvar_EnableFloat.BoolValue;
 	g_bEnableNameTag = g_Cvar_EnableNameTag.BoolValue;
 	g_bEnableStatTrak = g_Cvar_EnableStatTrak.BoolValue;
-    g_bEnableAllSkins = g_Cvar_EnableAllSkins.BoolValue;
-    g_bEnableSeed = g_Cvar_EnableSeed.BoolValue;
+	g_bEnableAllSkins = g_Cvar_EnableAllSkins.BoolValue;
+	g_bEnableSeed = g_Cvar_EnableSeed.BoolValue;
 	g_fFloatIncrementSize = g_Cvar_FloatIncrementSize.FloatValue;
 	g_iFloatIncrementPercentage = RoundFloat(g_fFloatIncrementSize * 100.0);
 	g_bOverwriteEnabled = g_Cvar_EnableWeaponOverwrite.BoolValue;
@@ -70,7 +70,7 @@ public void OnClientPutInServer(int client)
 		g_bWaitingForNametag[client] = false;
 		g_bWaitingForSeed[client] = false;
 		for (int i = 0; i < sizeof(g_WeaponClasses); i++)
-        {
+		{
 			g_iSeedRandom[client][i] = 0;
 		}
 		HookPlayer(client);

--- a/addons/sourcemod/scripting/weapons/globals.sp
+++ b/addons/sourcemod/scripting/weapons/globals.sp
@@ -77,14 +77,18 @@ int g_iGraceInactiveDays;
 int g_iSkins[MAXPLAYERS+1][sizeof(g_WeaponClasses)];
 int g_iStatTrak[MAXPLAYERS+1][sizeof(g_WeaponClasses)];
 int g_iStatTrakCount[MAXPLAYERS+1][sizeof(g_WeaponClasses)];
+int g_iWeaponSeed[MAXPLAYERS+1][sizeof(g_WeaponClasses)];
 char g_NameTag[MAXPLAYERS+1][sizeof(g_WeaponClasses)][128];
 float g_fFloatValue[MAXPLAYERS+1][sizeof(g_WeaponClasses)];
 
 int g_iIndex[MAXPLAYERS+1] = { 0, ... };
+int g_iSkinIndex[MAXPLAYERS + 1] = { 0, ... };
 Handle g_FloatTimer[MAXPLAYERS+1] = { INVALID_HANDLE, ... };
 int g_iSteam32[MAXPLAYERS+1] = { 0, ... };
 
 bool g_bWaitingForNametag[MAXPLAYERS+1] = { false, ... };
+bool g_bWaitingForSeed[MAXPLAYERS+1] = { false, ... };
+int g_iSeedRandom[MAXPLAYERS+1][sizeof(g_WeaponClasses)];
 
 int g_iKnife[MAXPLAYERS+1] = { 0, ... };
 

--- a/addons/sourcemod/scripting/weapons/globals.sp
+++ b/addons/sourcemod/scripting/weapons/globals.sp
@@ -65,6 +65,12 @@ bool g_bEnableNameTag;
 ConVar g_Cvar_EnableStatTrak;
 bool g_bEnableStatTrak;
 
+ConVar g_Cvar_EnableAllSkins;
+bool g_bEnableAllSkins;
+
+ConVar g_Cvar_EnableSeed;
+bool g_bEnableSeed;
+
 ConVar g_Cvar_EnableWeaponOverwrite;
 bool g_bOverwriteEnabled;
 

--- a/addons/sourcemod/scripting/weapons/helpers.sp
+++ b/addons/sourcemod/scripting/weapons/helpers.sp
@@ -50,11 +50,11 @@ stock int GetRandomSkin(int client, int index)
 
 stock bool IsValidClient(int client)
 {
-    if (!(1 <= client <= MaxClients) || !IsClientInGame(client) || IsFakeClient(client) || IsClientSourceTV(client) || IsClientReplay(client))
-    {
-        return false;
-    }
-    return true;
+	if (!(1 <= client <= MaxClients) || !IsClientInGame(client) || IsFakeClient(client) || IsClientSourceTV(client) || IsClientReplay(client))
+	{
+		return false;
+	}
+	return true;
 }
 
 stock int GetWeaponIndex(int entity)

--- a/addons/sourcemod/scripting/weapons/hooks.sp
+++ b/addons/sourcemod/scripting/weapons/hooks.sp
@@ -107,14 +107,14 @@ public Action ChatListener(int client, const char[] command, int args)
 	else if (g_bWaitingForSeed[client] && IsValidClient(client) && g_iIndex[client] > -1 && !IsChatTrigger()) {
 		
 		g_bWaitingForSeed[client] = false;
-		
+
 		int seedInt;
 		if (StrEqual(nameTag, "!cancel") || StrEqual(nameTag, "!iptal") || StrEqual(nameTag, "")) {
-			PrintToChat(client, " %s Seed operation aborted.", g_ChatPrefix);
+			PrintToChat(client, " %s\x02 %t", g_ChatPrefix, "SeedCancelled");
 			return Plugin_Handled;
 		}
 		else if ((seedInt = StringToInt(nameTag)) == -1 || seedInt < 0 || seedInt > 8192) {
-			PrintToChat(client, " %s Seed input out of range or invalid.", g_ChatPrefix);
+			PrintToChat(client, " %s\x02 %t", g_ChatPrefix, "SeedFailed");
 			return Plugin_Handled;
 		}
 
@@ -122,8 +122,10 @@ public Action ChatListener(int client, const char[] command, int args)
 		g_iSeedRandom[client][g_iIndex[client]] = -1;
 	
 		RefreshWeapon(client, g_iIndex[client]);
-	
 		CreateTimer(0.1, SeedMenuTimer, GetClientUserId(client));
+
+		PrintToChat(client, " %s \x04%t: \x01%i", g_ChatPrefix, "SeedSuccess", seedInt);
+
 		return Plugin_Handled;
 	}
 	

--- a/addons/sourcemod/scripting/weapons/hooks.sp
+++ b/addons/sourcemod/scripting/weapons/hooks.sp
@@ -104,6 +104,28 @@ public Action ChatListener(int client, const char[] command, int args)
 	
 		return Plugin_Handled;
 	}
+	else if (g_bWaitingForSeed[client] && IsValidClient(client) && g_iIndex[client] > -1 && !IsChatTrigger()) {
+		
+		g_bWaitingForSeed[client] = false;
+		
+		int seedInt;
+		if (StrEqual(nameTag, "!cancel") || StrEqual(nameTag, "!iptal") || StrEqual(nameTag, "")) {
+			PrintToChat(client, " %s Seed operation aborted.", g_ChatPrefix);
+			return Plugin_Handled;
+		}
+		else if ((seedInt = StringToInt(nameTag)) == -1 || seedInt < 0 || seedInt > 8192) {
+			PrintToChat(client, " %s Seed input out of range or invalid.", g_ChatPrefix);
+			return Plugin_Handled;
+		}
+
+		g_iWeaponSeed[client][g_iIndex[client]] = seedInt;
+        g_iSeedRandom[client][g_iIndex[client]] = -1;
+	
+		RefreshWeapon(client, g_iIndex[client]);
+	
+        CreateTimer(0.1, SeedMenuTimer, GetClientUserId(client));
+		return Plugin_Handled;
+	}
 	
 	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/weapons/hooks.sp
+++ b/addons/sourcemod/scripting/weapons/hooks.sp
@@ -119,11 +119,11 @@ public Action ChatListener(int client, const char[] command, int args)
 		}
 
 		g_iWeaponSeed[client][g_iIndex[client]] = seedInt;
-        g_iSeedRandom[client][g_iIndex[client]] = -1;
+		g_iSeedRandom[client][g_iIndex[client]] = -1;
 	
 		RefreshWeapon(client, g_iIndex[client]);
 	
-        CreateTimer(0.1, SeedMenuTimer, GetClientUserId(client));
+		CreateTimer(0.1, SeedMenuTimer, GetClientUserId(client));
 		return Plugin_Handled;
 	}
 	

--- a/addons/sourcemod/scripting/weapons/menus.sp
+++ b/addons/sourcemod/scripting/weapons/menus.sp
@@ -318,25 +318,25 @@ Menu CreateSeedMenu(int client)
 
 	if (g_iWeaponSeed[client][g_iIndex[client]] != -1)
 	{
-		Format(buffer, sizeof(buffer), "Seed: %i", g_iWeaponSeed[client][g_iIndex[client]]);
+		Format(buffer, sizeof(buffer), "%T", "SeedTitle", client, g_iWeaponSeed[client][g_iIndex[client]]);
 	}
 	else if (g_iSeedRandom[client][g_iIndex[client]] > 0)
 	{
-		Format(buffer, sizeof(buffer), "Seed: %i", g_iSeedRandom[client][g_iIndex[client]]);
+		Format(buffer, sizeof(buffer), "%T", "SeedTitle", client, g_iSeedRandom[client][g_iIndex[client]]);
 	}
 	else
 	{
-		Format(buffer, sizeof(buffer), "Seed: ∞");
+		Format(buffer, sizeof(buffer), "%T", "SeedTitleNoSeed", client);
 	}
 	menu.SetTitle(buffer);
 
-	Format(buffer, sizeof(buffer), "Use Random Seed");
+	Format(buffer, sizeof(buffer), "%T", "SeedRandom", client);
 	menu.AddItem("rseed", buffer);
 
-	Format(buffer, sizeof(buffer), "Manual Seed");
+	Format(buffer, sizeof(buffer), "%T", "SeedManual", client);
 	menu.AddItem("cseed", buffer);
 
-	Format(buffer, sizeof(buffer), "Save Current Seed");
+	Format(buffer, sizeof(buffer), "%T", "SeedSave", client);
 	menu.AddItem("sseed", buffer, g_iSeedRandom[client][g_iIndex[client]] == 0 ? ITEMDRAW_DISABLED : ITEMDRAW_DEFAULT);
 
 	menu.ExitBackButton = true;
@@ -368,7 +368,7 @@ public int SeedMenuHandler(Menu menu, MenuAction action, int client, int selecti
 				else if (StrEqual(buffer, "cseed"))
 				{					
 					g_bWaitingForSeed[client] = true;
-					PrintToChat(client, " %s Write your desired seed into chat. To abort, type !cancel", g_ChatPrefix);
+					PrintToChat(client, " %s \x04%t", g_ChatPrefix, "SeedInstruction");
 				}
 				else if (StrEqual(buffer, "sseed"))
 				{	
@@ -379,7 +379,7 @@ public int SeedMenuHandler(Menu menu, MenuAction action, int client, int selecti
 					g_iSeedRandom[client][g_iIndex[client]] = 0;
 					RefreshWeapon(client, g_iIndex[client]);
 
-					PrintToChat(client, " %s Seed saved.", g_ChatPrefix);
+					PrintToChat(client, " %s \x04%t", g_ChatPrefix, "SeedSaved");
 
 					char updateFields[256];
 					char weaponName[32];
@@ -614,13 +614,13 @@ public Action NameTagColorsMenuTimer(Handle timer, int userid)
 Menu CreateAllSkinsMenu(int client)
 {
 	Menu menu = new Menu(AllSkinsMenuHandler);
-	menu.SetTitle("All Skins");
+	menu.SetTitle("%T", "AllSkins", client);
 
-	char name[32];
+	char buffer[60];
 	for (int i = 0; i < sizeof(g_WeaponClasses); i++)
 	{
-		Format(name, sizeof(name), "%T", g_WeaponClasses[i], client);
-		menu.AddItem(g_WeaponClasses[i], name);
+		Format(buffer, sizeof(buffer), "%T", client, g_WeaponClasses[i]);
+		menu.AddItem(g_WeaponClasses[i], buffer);
 	}
 	
 	menu.ExitBackButton = true;
@@ -671,7 +671,10 @@ public int AllSkinsMenuHandler(Menu menu, MenuAction action, int client, int sel
 Menu CreateSkinsMenu(int client, int index)
 {
 	Menu menu = new Menu(SkinMenuHandler);
-	menu.SetTitle("Skins for: %T", g_WeaponClasses[index], LANG_SERVER);
+
+	char buffer[60];
+	Format(buffer, sizeof(buffer), "%T", client, g_WeaponClasses[index]);
+	menu.SetTitle("AllSkinsSub", client, buffer);
 
 	char idTemp[4];
 	char infoTemp[32];
@@ -760,7 +763,7 @@ Menu CreateAllWeaponsMenu(int client)
 	char name[32];
 	for (int i = 0; i < sizeof(g_WeaponClasses); i++)
 	{
-		Format(name, sizeof(name), "%T", g_WeaponClasses[i], client);
+		Format(name, sizeof(name), "%T", client, g_WeaponClasses[i]);
 		menu.AddItem(g_WeaponClasses[i], name);
 	}
 	
@@ -820,7 +823,7 @@ Menu CreateWeaponMenu(int client)
 	
 	if (g_bEnableAllSkins)
 	{
-		Format(buffer, sizeof(buffer), "Skin From All");
+		Format(buffer, sizeof(buffer), "%T", "AllSkins", client);
 		menu.AddItem("allskins", buffer);
 	}
 

--- a/addons/sourcemod/scripting/weapons/menus.sp
+++ b/addons/sourcemod/scripting/weapons/menus.sp
@@ -115,6 +115,14 @@ public int WeaponMenuHandler(Menu menu, MenuAction action, int client, int selec
 						menuWeapons[g_iClientLanguage[client]][g_iIndex[client]].Display(client, menuTime);
 					}
 				}
+                else if(StrEqual(buffer, "allskins"))
+                {
+                    int menuTime;
+					if((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
+					{
+						CreateAllSkinsMenu(client).Display(client, menuTime);
+					}
+                }
 				else if(StrEqual(buffer, "float"))
 				{
 					int menuTime;
@@ -142,6 +150,14 @@ public int WeaponMenuHandler(Menu menu, MenuAction action, int client, int selec
 					if((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
 					{
 						CreateNameTagMenu(client).Display(client, menuTime);
+					}
+				}
+				else if (StrEqual(buffer, "seed"))
+                {
+					int menuTime;
+					if ((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
+                    {
+						CreateSeedMenu(client).Display(client, menuTime);
 					}
 				}
 			}
@@ -292,6 +308,117 @@ public Action FloatTimer(Handle timer, DataPack pack)
 	}
 	
 	g_FloatTimer[clientIndex] = INVALID_HANDLE;
+}
+
+Menu CreateSeedMenu(int client)
+{
+	Menu menu = new Menu(SeedMenuHandler);
+
+	char buffer[128];
+
+	if (g_iWeaponSeed[client][g_iIndex[client]] != -1)
+    {
+		Format(buffer, sizeof(buffer), "Seed: %i", g_iWeaponSeed[client][g_iIndex[client]]);
+	}
+    else if (g_iSeedRandom[client][g_iIndex[client]] > 0)
+    {
+		Format(buffer, sizeof(buffer), "Seed: %i", g_iSeedRandom[client][g_iIndex[client]]);
+	}
+    else
+    {
+		Format(buffer, sizeof(buffer), "Seed: ∞");
+	}
+	menu.SetTitle(buffer);
+
+	Format(buffer, sizeof(buffer), "Use Random Seed");
+	menu.AddItem("rseed", buffer);
+
+	Format(buffer, sizeof(buffer), "Manual Seed");
+	menu.AddItem("cseed", buffer);
+
+	Format(buffer, sizeof(buffer), "Save Current Seed");
+	menu.AddItem("sseed", buffer, g_iSeedRandom[client][g_iIndex[client]] == 0 ? ITEMDRAW_DISABLED : ITEMDRAW_DEFAULT);
+
+	menu.ExitBackButton = true;
+	
+	return menu;
+}
+
+public int SeedMenuHandler(Menu menu, MenuAction action, int client, int selection)
+{
+	switch(action)
+	{
+		case MenuAction_Select:
+		{
+			if(IsClientInGame(client))
+			{
+				char buffer[30];
+				menu.GetItem(selection, buffer, sizeof(buffer));
+				if(StrEqual(buffer, "rseed"))
+				{
+					g_iWeaponSeed[client][g_iIndex[client]] = -1;
+					RefreshWeapon(client, g_iIndex[client]);
+
+					char updateFields[256];
+					char weaponName[32];
+					RemoveWeaponPrefix(g_WeaponClasses[g_iIndex[client]], weaponName, sizeof(weaponName));
+					Format(updateFields, sizeof(updateFields), "%s_seed = %d", weaponName, g_iWeaponSeed[client][g_iIndex[client]]);
+					UpdatePlayerData(client, updateFields);
+				}
+                else if (StrEqual(buffer, "cseed"))
+                {					
+					g_bWaitingForSeed[client] = true;
+					PrintToChat(client, " %s Write your desired seed into chat. To abort, type !cancel", g_ChatPrefix);
+				}
+                else if (StrEqual(buffer, "sseed"))
+                {	
+                    if(g_iSeedRandom[client][g_iIndex[client]] > 0) 
+                    {
+                        g_iWeaponSeed[client][g_iIndex[client]] = g_iSeedRandom[client][g_iIndex[client]];
+                    }
+                    g_iSeedRandom[client][g_iIndex[client]] = 0;
+					RefreshWeapon(client, g_iIndex[client]);
+
+					PrintToChat(client, " %s Seed saved.", g_ChatPrefix);
+
+					char updateFields[256];
+					char weaponName[32];
+					RemoveWeaponPrefix(g_WeaponClasses[g_iIndex[client]], weaponName, sizeof(weaponName));
+					Format(updateFields, sizeof(updateFields), "%s_seed = %d", weaponName, g_iWeaponSeed[client][g_iIndex[client]]);
+					UpdatePlayerData(client, updateFields);
+				}
+                CreateTimer(0.1, SeedMenuTimer, GetClientUserId(client));
+			}
+		}
+		case MenuAction_Cancel:
+		{
+			if(IsClientInGame(client) && selection == MenuCancel_ExitBack)
+			{
+				int menuTime;
+				if((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
+				{
+					CreateWeaponMenu(client).Display(client, menuTime);
+				}
+			}
+		}
+		case MenuAction_End:
+		{
+			delete menu;
+		}
+	}
+}
+
+public Action SeedMenuTimer(Handle timer, int userid)
+{
+	int clientIndex = GetClientOfUserId(userid);
+	if(IsValidClient(clientIndex))
+	{
+		int menuTime;
+		if((menuTime = GetRemainingGracePeriodSeconds(clientIndex)) >= 0)
+		{
+			CreateSeedMenu(clientIndex).Display(clientIndex, menuTime);
+		}
+	}
 }
 
 Menu CreateNameTagMenu(int client)
@@ -484,6 +611,149 @@ public Action NameTagColorsMenuTimer(Handle timer, int userid)
 	}
 }
 */
+Menu CreateAllSkinsMenu(int client)
+{
+    Menu menu = new Menu(AllSkinsMenuHandler);
+    menu.SetTitle("All Skins");
+
+    char name[32];
+    for (int i = 0; i < sizeof(g_WeaponClasses); i++)
+	{
+		Format(name, sizeof(name), "%T", g_WeaponClasses[i], client);
+		menu.AddItem(g_WeaponClasses[i], name);
+	}
+	
+	menu.ExitBackButton = true;
+	
+	return menu;
+}
+
+public int AllSkinsMenuHandler(Menu menu, MenuAction action, int client, int selection)
+{
+	switch(action)
+	{
+		case MenuAction_Select:
+		{
+			if(IsClientInGame(client))
+			{
+				char class[30];
+				menu.GetItem(selection, class, sizeof(class));
+				
+                int iClass;
+				g_smWeaponIndex.GetValue(class, iClass);
+                g_iSkinIndex[client] = iClass;
+
+                int menuTime;
+                if((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
+                {
+                    CreateSkinsMenu(client, iClass).Display(client, menuTime);
+                }
+			}
+		}
+		case MenuAction_Cancel:
+		{
+			if(IsClientInGame(client) && selection == MenuCancel_ExitBack)
+			{
+				int menuTime;
+				if((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
+				{
+					CreateWeaponMenu(client).Display(client, menuTime);
+				}
+			}
+		}
+		case MenuAction_End:
+		{
+			delete menu;
+		}
+	}
+}
+
+Menu CreateSkinsMenu(int client, int index)
+{
+    Menu menu = new Menu(SkinMenuHandler);
+    
+    char title[32];
+    menu.SetTitle("Skins for: %T", g_WeaponClasses[index], LANG_SERVER);
+
+    char idTemp[4];
+    char infoTemp[32];
+
+    int max = menuWeapons[g_iClientLanguage[client]][index].ItemCount;
+    for(int i = 2; i <= max; i++)
+    {
+        menuWeapons[g_iClientLanguage[client]][index].GetItem(i, idTemp, sizeof(idTemp), _, infoTemp, sizeof(infoTemp));
+        menu.AddItem(idTemp, infoTemp);
+    }
+
+    menu.ExitBackButton = true;
+    return menu;
+}
+
+public int SkinMenuHandler(Menu menu, MenuAction action, int client, int selection)
+{
+	switch(action)
+	{
+		case MenuAction_Select:
+		{
+			if(IsClientInGame(client))
+			{
+				int index = g_iIndex[client];
+				
+                char skinIdStr[32];
+                menu.GetItem(selection, skinIdStr, sizeof(skinIdStr));
+                int skinId = StringToInt(skinIdStr);
+
+                g_iSkins[client][index] = skinId;
+                char updateFields[256];
+                char weaponName[32];
+                RemoveWeaponPrefix(g_WeaponClasses[index], weaponName, sizeof(weaponName));
+                Format(updateFields, sizeof(updateFields), "%s = %d", weaponName, skinId);
+                UpdatePlayerData(client, updateFields);
+
+                RefreshWeapon(client, index);
+
+                DataPack pack;
+                CreateDataTimer(0.1, SkinsMenuTimer, pack);
+                pack.WriteCell(GetClientUserId(client));
+                pack.WriteCell(index);
+                pack.WriteCell(GetMenuSelectionPosition());
+			}
+		}
+		case MenuAction_Cancel:
+		{
+			if(IsClientInGame(client) && selection == MenuCancel_ExitBack)
+			{
+				int menuTime;
+				if((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
+				{
+					CreateAllSkinsMenu(client).Display(client, menuTime);
+				}
+			}
+		}
+		case MenuAction_End:
+		{
+			delete menu;
+		}
+	}
+}
+
+public Action SkinsMenuTimer(Handle timer, DataPack pack)
+{
+	ResetPack(pack);
+	int clientIndex = GetClientOfUserId(pack.ReadCell());
+    int wepIndex = pack.ReadCell();
+	int menuSelectionPosition = pack.ReadCell();
+	
+	if(IsValidClient(clientIndex))
+	{
+		int menuTime;
+		if((menuTime = GetRemainingGracePeriodSeconds(clientIndex)) >= 0)
+		{
+            Menu menu = CreateSkinsMenu(clientIndex, g_iSkinIndex[clientIndex]);
+			menu.DisplayAt(clientIndex, menuSelectionPosition, menuTime);
+		}
+	}
+}
 
 Menu CreateAllWeaponsMenu(int client)
 {
@@ -551,6 +821,9 @@ Menu CreateWeaponMenu(int client)
 	Format(buffer, sizeof(buffer), "%T", "SetSkin", client);
 	menu.AddItem("skin", buffer);
 	
+    Format(buffer, sizeof(buffer), "Skin From All");
+    menu.AddItem("allskins", buffer);
+
 	bool weaponHasSkin = (g_iSkins[client][index] != 0);
 	
 	if (g_bEnableFloat)
@@ -581,6 +854,10 @@ Menu CreateWeaponMenu(int client)
 		menu.AddItem("nametag", buffer, weaponHasSkin ? ITEMDRAW_DEFAULT : ITEMDRAW_DISABLED);
 	}
 	
+	Format(buffer, sizeof(buffer), "Seed", client);
+	menu.AddItem("seed", buffer, weaponHasSkin ? ITEMDRAW_DEFAULT : ITEMDRAW_DISABLED);
+
+
 	menu.ExitBackButton = true;
 	
 	return menu;

--- a/addons/sourcemod/scripting/weapons/menus.sp
+++ b/addons/sourcemod/scripting/weapons/menus.sp
@@ -115,14 +115,14 @@ public int WeaponMenuHandler(Menu menu, MenuAction action, int client, int selec
 						menuWeapons[g_iClientLanguage[client]][g_iIndex[client]].Display(client, menuTime);
 					}
 				}
-                else if(StrEqual(buffer, "allskins"))
-                {
-                    int menuTime;
+				else if(StrEqual(buffer, "allskins"))
+				{
+					int menuTime;
 					if((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
 					{
 						CreateAllSkinsMenu(client).Display(client, menuTime);
 					}
-                }
+				}
 				else if(StrEqual(buffer, "float"))
 				{
 					int menuTime;
@@ -153,10 +153,10 @@ public int WeaponMenuHandler(Menu menu, MenuAction action, int client, int selec
 					}
 				}
 				else if (StrEqual(buffer, "seed"))
-                {
+				{
 					int menuTime;
 					if ((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
-                    {
+					{
 						CreateSeedMenu(client).Display(client, menuTime);
 					}
 				}
@@ -317,15 +317,15 @@ Menu CreateSeedMenu(int client)
 	char buffer[128];
 
 	if (g_iWeaponSeed[client][g_iIndex[client]] != -1)
-    {
+	{
 		Format(buffer, sizeof(buffer), "Seed: %i", g_iWeaponSeed[client][g_iIndex[client]]);
 	}
-    else if (g_iSeedRandom[client][g_iIndex[client]] > 0)
-    {
+	else if (g_iSeedRandom[client][g_iIndex[client]] > 0)
+	{
 		Format(buffer, sizeof(buffer), "Seed: %i", g_iSeedRandom[client][g_iIndex[client]]);
 	}
-    else
-    {
+	else
+	{
 		Format(buffer, sizeof(buffer), "Seed: ∞");
 	}
 	menu.SetTitle(buffer);
@@ -365,18 +365,18 @@ public int SeedMenuHandler(Menu menu, MenuAction action, int client, int selecti
 					Format(updateFields, sizeof(updateFields), "%s_seed = %d", weaponName, g_iWeaponSeed[client][g_iIndex[client]]);
 					UpdatePlayerData(client, updateFields);
 				}
-                else if (StrEqual(buffer, "cseed"))
-                {					
+				else if (StrEqual(buffer, "cseed"))
+				{					
 					g_bWaitingForSeed[client] = true;
 					PrintToChat(client, " %s Write your desired seed into chat. To abort, type !cancel", g_ChatPrefix);
 				}
-                else if (StrEqual(buffer, "sseed"))
-                {	
-                    if(g_iSeedRandom[client][g_iIndex[client]] > 0) 
-                    {
-                        g_iWeaponSeed[client][g_iIndex[client]] = g_iSeedRandom[client][g_iIndex[client]];
-                    }
-                    g_iSeedRandom[client][g_iIndex[client]] = 0;
+				else if (StrEqual(buffer, "sseed"))
+				{	
+					if(g_iSeedRandom[client][g_iIndex[client]] > 0) 
+					{
+						g_iWeaponSeed[client][g_iIndex[client]] = g_iSeedRandom[client][g_iIndex[client]];
+					}
+					g_iSeedRandom[client][g_iIndex[client]] = 0;
 					RefreshWeapon(client, g_iIndex[client]);
 
 					PrintToChat(client, " %s Seed saved.", g_ChatPrefix);
@@ -387,7 +387,7 @@ public int SeedMenuHandler(Menu menu, MenuAction action, int client, int selecti
 					Format(updateFields, sizeof(updateFields), "%s_seed = %d", weaponName, g_iWeaponSeed[client][g_iIndex[client]]);
 					UpdatePlayerData(client, updateFields);
 				}
-                CreateTimer(0.1, SeedMenuTimer, GetClientUserId(client));
+				CreateTimer(0.1, SeedMenuTimer, GetClientUserId(client));
 			}
 		}
 		case MenuAction_Cancel:
@@ -613,11 +613,11 @@ public Action NameTagColorsMenuTimer(Handle timer, int userid)
 */
 Menu CreateAllSkinsMenu(int client)
 {
-    Menu menu = new Menu(AllSkinsMenuHandler);
-    menu.SetTitle("All Skins");
+	Menu menu = new Menu(AllSkinsMenuHandler);
+	menu.SetTitle("All Skins");
 
-    char name[32];
-    for (int i = 0; i < sizeof(g_WeaponClasses); i++)
+	char name[32];
+	for (int i = 0; i < sizeof(g_WeaponClasses); i++)
 	{
 		Format(name, sizeof(name), "%T", g_WeaponClasses[i], client);
 		menu.AddItem(g_WeaponClasses[i], name);
@@ -639,15 +639,15 @@ public int AllSkinsMenuHandler(Menu menu, MenuAction action, int client, int sel
 				char class[30];
 				menu.GetItem(selection, class, sizeof(class));
 				
-                int iClass;
+				int iClass;
 				g_smWeaponIndex.GetValue(class, iClass);
-                g_iSkinIndex[client] = iClass;
+				g_iSkinIndex[client] = iClass;
 
-                int menuTime;
-                if((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
-                {
-                    CreateSkinsMenu(client, iClass).Display(client, menuTime);
-                }
+				int menuTime;
+				if((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
+				{
+					CreateSkinsMenu(client, iClass).Display(client, menuTime);
+				}
 			}
 		}
 		case MenuAction_Cancel:
@@ -670,21 +670,21 @@ public int AllSkinsMenuHandler(Menu menu, MenuAction action, int client, int sel
 
 Menu CreateSkinsMenu(int client, int index)
 {
-    Menu menu = new Menu(SkinMenuHandler);
-    menu.SetTitle("Skins for: %T", g_WeaponClasses[index], LANG_SERVER);
+	Menu menu = new Menu(SkinMenuHandler);
+	menu.SetTitle("Skins for: %T", g_WeaponClasses[index], LANG_SERVER);
 
-    char idTemp[4];
-    char infoTemp[32];
+	char idTemp[4];
+	char infoTemp[32];
 
-    int max = menuWeapons[g_iClientLanguage[client]][index].ItemCount;
-    for(int i = 2; i <= max; i++)
-    {
-        menuWeapons[g_iClientLanguage[client]][index].GetItem(i, idTemp, sizeof(idTemp), _, infoTemp, sizeof(infoTemp));
-        menu.AddItem(idTemp, infoTemp);
-    }
+	int max = menuWeapons[g_iClientLanguage[client]][index].ItemCount;
+	for(int i = 2; i <= max; i++)
+	{
+		menuWeapons[g_iClientLanguage[client]][index].GetItem(i, idTemp, sizeof(idTemp), _, infoTemp, sizeof(infoTemp));
+		menu.AddItem(idTemp, infoTemp);
+	}
 
-    menu.ExitBackButton = true;
-    return menu;
+	menu.ExitBackButton = true;
+	return menu;
 }
 
 public int SkinMenuHandler(Menu menu, MenuAction action, int client, int selection)
@@ -697,24 +697,24 @@ public int SkinMenuHandler(Menu menu, MenuAction action, int client, int selecti
 			{
 				int index = g_iIndex[client];
 				
-                char skinIdStr[32];
-                menu.GetItem(selection, skinIdStr, sizeof(skinIdStr));
-                int skinId = StringToInt(skinIdStr);
+				char skinIdStr[32];
+				menu.GetItem(selection, skinIdStr, sizeof(skinIdStr));
+				int skinId = StringToInt(skinIdStr);
 
-                g_iSkins[client][index] = skinId;
-                char updateFields[256];
-                char weaponName[32];
-                RemoveWeaponPrefix(g_WeaponClasses[index], weaponName, sizeof(weaponName));
-                Format(updateFields, sizeof(updateFields), "%s = %d", weaponName, skinId);
-                UpdatePlayerData(client, updateFields);
+				g_iSkins[client][index] = skinId;
+				char updateFields[256];
+				char weaponName[32];
+				RemoveWeaponPrefix(g_WeaponClasses[index], weaponName, sizeof(weaponName));
+				Format(updateFields, sizeof(updateFields), "%s = %d", weaponName, skinId);
+				UpdatePlayerData(client, updateFields);
 
-                RefreshWeapon(client, index);
+				RefreshWeapon(client, index);
 
-                DataPack pack;
-                CreateDataTimer(0.1, SkinsMenuTimer, pack);
-                pack.WriteCell(GetClientUserId(client));
-                pack.WriteCell(index);
-                pack.WriteCell(GetMenuSelectionPosition());
+				DataPack pack;
+				CreateDataTimer(0.1, SkinsMenuTimer, pack);
+				pack.WriteCell(GetClientUserId(client));
+				pack.WriteCell(index);
+				pack.WriteCell(GetMenuSelectionPosition());
 			}
 		}
 		case MenuAction_Cancel:
@@ -746,7 +746,7 @@ public Action SkinsMenuTimer(Handle timer, DataPack pack)
 		int menuTime;
 		if((menuTime = GetRemainingGracePeriodSeconds(clientIndex)) >= 0)
 		{
-            Menu menu = CreateSkinsMenu(clientIndex, g_iSkinIndex[clientIndex]);
+			Menu menu = CreateSkinsMenu(clientIndex, g_iSkinIndex[clientIndex]);
 			menu.DisplayAt(clientIndex, menuSelectionPosition, menuTime);
 		}
 	}
@@ -818,11 +818,11 @@ Menu CreateWeaponMenu(int client)
 	Format(buffer, sizeof(buffer), "%T", "SetSkin", client);
 	menu.AddItem("skin", buffer);
 	
-    if (g_bEnableAllSkins)
-    {
-        Format(buffer, sizeof(buffer), "Skin From All");
-        menu.AddItem("allskins", buffer);
-    }
+	if (g_bEnableAllSkins)
+	{
+		Format(buffer, sizeof(buffer), "Skin From All");
+		menu.AddItem("allskins", buffer);
+	}
 
 	bool weaponHasSkin = (g_iSkins[client][index] != 0);
 	
@@ -854,11 +854,11 @@ Menu CreateWeaponMenu(int client)
 		menu.AddItem("nametag", buffer, weaponHasSkin ? ITEMDRAW_DEFAULT : ITEMDRAW_DISABLED);
 	}
 	
-    if (g_bEnableSeed)
-    {
-        Format(buffer, sizeof(buffer), "Seed", client);
-        menu.AddItem("seed", buffer, weaponHasSkin ? ITEMDRAW_DEFAULT : ITEMDRAW_DISABLED);
-    }
+	if (g_bEnableSeed)
+	{
+		Format(buffer, sizeof(buffer), "Seed", client);
+		menu.AddItem("seed", buffer, weaponHasSkin ? ITEMDRAW_DEFAULT : ITEMDRAW_DISABLED);
+	}
 
 	menu.ExitBackButton = true;
 	

--- a/addons/sourcemod/scripting/weapons/menus.sp
+++ b/addons/sourcemod/scripting/weapons/menus.sp
@@ -619,7 +619,7 @@ Menu CreateAllSkinsMenu(int client)
 	char buffer[60];
 	for (int i = 0; i < sizeof(g_WeaponClasses); i++)
 	{
-		Format(buffer, sizeof(buffer), "%T", client, g_WeaponClasses[i]);
+		Format(buffer, sizeof(buffer), "%T", g_WeaponClasses[i], client);
 		menu.AddItem(g_WeaponClasses[i], buffer);
 	}
 	
@@ -673,8 +673,8 @@ Menu CreateSkinsMenu(int client, int index)
 	Menu menu = new Menu(SkinMenuHandler);
 
 	char buffer[60];
-	Format(buffer, sizeof(buffer), "%T", client, g_WeaponClasses[index]);
-	menu.SetTitle("AllSkinsSub", client, buffer);
+	Format(buffer, sizeof(buffer), "%T", g_WeaponClasses[index], client);
+	menu.SetTitle("%T", "AllSkinsSub", client, buffer);
 
 	char idTemp[4];
 	char infoTemp[32];
@@ -763,7 +763,7 @@ Menu CreateAllWeaponsMenu(int client)
 	char name[32];
 	for (int i = 0; i < sizeof(g_WeaponClasses); i++)
 	{
-		Format(name, sizeof(name), "%T", client, g_WeaponClasses[i]);
+		Format(name, sizeof(name), "%T", g_WeaponClasses[i], client);
 		menu.AddItem(g_WeaponClasses[i], name);
 	}
 	

--- a/addons/sourcemod/scripting/weapons/menus.sp
+++ b/addons/sourcemod/scripting/weapons/menus.sp
@@ -671,8 +671,6 @@ public int AllSkinsMenuHandler(Menu menu, MenuAction action, int client, int sel
 Menu CreateSkinsMenu(int client, int index)
 {
     Menu menu = new Menu(SkinMenuHandler);
-    
-    char title[32];
     menu.SetTitle("Skins for: %T", g_WeaponClasses[index], LANG_SERVER);
 
     char idTemp[4];
@@ -741,7 +739,6 @@ public Action SkinsMenuTimer(Handle timer, DataPack pack)
 {
 	ResetPack(pack);
 	int clientIndex = GetClientOfUserId(pack.ReadCell());
-    int wepIndex = pack.ReadCell();
 	int menuSelectionPosition = pack.ReadCell();
 	
 	if(IsValidClient(clientIndex))
@@ -821,8 +818,11 @@ Menu CreateWeaponMenu(int client)
 	Format(buffer, sizeof(buffer), "%T", "SetSkin", client);
 	menu.AddItem("skin", buffer);
 	
-    Format(buffer, sizeof(buffer), "Skin From All");
-    menu.AddItem("allskins", buffer);
+    if (g_bEnableAllSkins)
+    {
+        Format(buffer, sizeof(buffer), "Skin From All");
+        menu.AddItem("allskins", buffer);
+    }
 
 	bool weaponHasSkin = (g_iSkins[client][index] != 0);
 	
@@ -854,9 +854,11 @@ Menu CreateWeaponMenu(int client)
 		menu.AddItem("nametag", buffer, weaponHasSkin ? ITEMDRAW_DEFAULT : ITEMDRAW_DISABLED);
 	}
 	
-	Format(buffer, sizeof(buffer), "Seed", client);
-	menu.AddItem("seed", buffer, weaponHasSkin ? ITEMDRAW_DEFAULT : ITEMDRAW_DISABLED);
-
+    if (g_bEnableSeed)
+    {
+        Format(buffer, sizeof(buffer), "Seed", client);
+        menu.AddItem("seed", buffer, weaponHasSkin ? ITEMDRAW_DEFAULT : ITEMDRAW_DISABLED);
+    }
 
 	menu.ExitBackButton = true;
 	

--- a/addons/sourcemod/translations/weapons.phrases.txt
+++ b/addons/sourcemod/translations/weapons.phrases.txt
@@ -336,4 +336,52 @@
 	{
 		"en"	"Name tag successfully applied"
 	}
+	"AllSkins"
+	{
+		"en"	"Skin From All"
+	}
+	"AllSkinsSub"
+	{
+		"en"	"Skins for: %s"
+	}
+	"SeedTitle"
+	{
+		"en"	"Seed: %i"
+	}
+	"SeedTitleNoSeed"
+	{
+		"en"	"Seed: ∞"
+	}
+	"SeedRandom"
+	{
+		"en"	"Use Random Seed"
+	}
+	"SeedManual"
+	{
+		"en"	"Manual Seed"
+	}
+	"SeedSave"
+	{
+		"en"	"Save Current Seed"
+	}
+	"SeedInstruction"
+	{
+		"en"	"Write your desired seed into chat. To abort, type !cancel."
+	}
+	"SeedSuccess"
+	{
+		"en"	"Seed successfully applied"
+	}
+	"SeedCancelled"
+	{
+		"en"	"Seed operation aborted."
+	}
+	"SeedFailed"
+	{
+		"en"	"Invalid seed (0 - 8192)"
+	}
+	"SeedSaved"
+	{
+		"en"	"Seed saved."
+	}
 }

--- a/cfg/sourcemod/weapons.cfg
+++ b/cfg/sourcemod/weapons.cfg
@@ -31,6 +31,16 @@ sm_weapons_enable_overwrite "0"
 // Default: "1"
 sm_weapons_enable_stattrak "1"
 
+// Enable/Disable All Skins options
+// -
+// Default: "1"
+sm_weapons_enable_allskins "1"
+
+// Enable/Disable Seed options
+// -
+// Default: "1"
+sm_weapons_enable_seed "1"
+
 // Increase/Decrease by value for weapon float
 // -
 // Default: "0.05"


### PR DESCRIPTION
adds 2 convars:
sm_weapons_enable_seed "1"
sm_weapons_enable_allskins "1"

and the ability for players to set their weapon skin seed and select a skin from any weapon, as opposed to just the target weapon.