### PR TITLE
Update Translations Portuguese-BR & English

### DIFF
--- a/addons/sourcemod/translations/pt/weapons.phrases.txt
+++ b/addons/sourcemod/translations/pt/weapons.phrases.txt
@@ -422,7 +422,7 @@
 	}
 	"SeedExplanation"
 	{
-		"pt"	"Você deve usar o menu  !ws para definir a seed para skins."
+		"pt"	"Você deve usar o menu !ws para definir o seed para skins."
 	}
 	"SeedReset"
 	{

--- a/addons/sourcemod/translations/pt/weapons.phrases.txt
+++ b/addons/sourcemod/translations/pt/weapons.phrases.txt
@@ -2,7 +2,7 @@
 {
 	"WSMenuTitle"
 	{
-		"pt"	"Weapon Skins Menu"
+		"pt"	"Menu de Skins"
 	}
 	"ChooseKnife"
 	{

--- a/addons/sourcemod/translations/pt/weapons.phrases.txt
+++ b/addons/sourcemod/translations/pt/weapons.phrases.txt
@@ -282,7 +282,7 @@
 	}
 	"weapon_knife_butterfly"
 	{
-		"pt"	"★ Butterfly Knife"
+		"pt"	"★ Butterfly Knifee"
 	}
 	"weapon_knife_falchion"
 	{

--- a/addons/sourcemod/translations/pt/weapons.phrases.txt
+++ b/addons/sourcemod/translations/pt/weapons.phrases.txt
@@ -6,39 +6,39 @@
 	}
 	"ChooseKnife"
 	{
-		"pt"	"★ Mudar Suas Facas ★"
+		"pt"	"★ Mudar sua Faca ★"
 	}
 	"ConfigAllWeapons"
 	{
-		"pt"	"Configurar Todas As Armas"
+		"pt"	"Configurar Todas as Armas"
 	}
 	"KnifeMenuTitle"
 	{
-		"pt"	"★ Seleção De Facas ★"
+		"pt"	"★ Seleção de Faca ★"
 	}
 	"AllWeaponsMenuTitle"
 	{
-		"pt"	"Todas As Armas"
+		"pt"	"Todas as Armas"
 	}
 	"Increase"
 	{
-		"pt"	"Aumentar %d%%"
+		"pt"	"Aumentar em %d%%"
 	}
 	"Decrease"
 	{
-		"pt"	"Diminuir %d%%"
+		"pt"	"Diminuir em %d%%"
 	}
 	"NameTagInfo"
 	{
-		"pt"	"Use !nametag <tag> para escolher uma name tag para sua arma atual!"
+		"pt"	"Use !nametag <tag> para escolher uma nametag para sua arma atual!"
 	}
 	"NameTagColor"
 	{
-		"pt"	"Escolher cor da name tag"
+		"pt"	"Escolher cor da nametag"
 	}
 	"NameTagDisabled"
 	{
-		"pt"	"O uso da name tag está desabilitado no momento."
+		"pt"	"O uso da nametag está desabilitado no momento."
 	}
 	"DontSpamNameTag"
 	{
@@ -50,7 +50,7 @@
 	}
 	"ChooseLanguage"
 	{
-		"pt"	"Escolha uma linguagem para as suas skins:"
+		"pt"	"Selecione o idioma para nomes de skin:"
 	}
 	"ChooseColor"
 	{
@@ -90,7 +90,7 @@
 	}
 	"DeleteNameTag"
 	{
-		"pt"	"Apagar Name Tag"
+		"pt"	"Apagar NameTag"
 	}
 	"OwnKnife"
 	{
@@ -98,11 +98,11 @@
 	}
 	"SetSkin"
 	{
-		"pt"	"Escolha uma skin"
+		"pt"	"Escolha uma Skin"
 	}
 	"SetFloat"
 	{
-		"pt"	"Condição da arma: "
+		"pt"	"Condição da Arma: "
 	}
 	"StatTrak"
 	{
@@ -110,7 +110,7 @@
 	}
 	"SetNameTag"
 	{
-		"pt"	"Name Tag: "
+		"pt"	"NameTag"
 	}
 	"On"
 	{
@@ -142,7 +142,7 @@
 	}
 	"weapon_revolver"
 	{
-		"pt"	"Revólver R8"
+		"pt"	"R8 Revolver"
 	}
 	"weapon_deagle"
 	{
@@ -158,7 +158,7 @@
 	}
 	"weapon_sawedoff"
 	{
-		"pt"	"Cano curto"
+		"pt"	"Sawed-Off"
 	}
 	"weapon_negev"
 	{
@@ -198,7 +198,7 @@
 	}
 	"weapon_elite"
 	{
-		"pt"	"Berettas Duplas"
+		"pt"	"Dual Berettas"
 	}
 	"weapon_m249"
 	{
@@ -252,21 +252,25 @@
 	{
 		"pt"	"Glock-18"
 	}
+	"weapon_mp5sd"
+	{
+		"pt"	"MP5-SD"
+	}
 	"weapon_bayonet"
 	{
-		"pt"	"★ Baioneta"
+		"pt"	"★ Bayonet"
 	}
 	"weapon_knife_gut"
 	{
-		"pt"	"★ Gut Hook"
+		"pt"	"★ Gut Knife"
 	}
 	"weapon_knife_flip"
 	{
-		"pt"	"★ Canivete"
+		"pt"	"★ Flip Knife"
 	}
 	"weapon_knife_m9_bayonet"
 	{
-		"pt"	"★ Baioneta M9"
+		"pt"	"★ M9 Bayonet"
 	}
 	"weapon_knife_karambit"
 	{
@@ -274,23 +278,59 @@
 	}
 	"weapon_knife_tactical"
 	{
-		"pt"	"★ Faca de caçador"
+		"pt"	"★ Huntsman Knife"
 	}
 	"weapon_knife_butterfly"
 	{
-		"pt"	"★ Canivete borboleta"
+		"pt"	"★ Butterfly Knife"
 	}
 	"weapon_knife_falchion"
 	{
-		"pt"	"★ Canivete Falchion"
+		"pt"	"★ Falchion Knife"
 	}
 	"weapon_knife_push"
 	{
-		"pt"	"★ Adagas Sombrias"
+		"pt"	"★ Shadow Daggers"
 	}
 	"weapon_knife_survival_bowie"
 	{
-		"pt"	"★ Faca Bowie"
+		"pt"	"★ Bowie Knife"
+	}
+	"weapon_knife_ursus"
+	{
+		"pt"	"★ Ursus"
+	}
+	"weapon_knife_gypsy_jackknife"
+	{
+		"pt"	"★ Navaja"
+	}
+	"weapon_knife_stiletto"
+	{
+		"pt"	"★ Stiletto"
+	}
+	"weapon_knife_widowmaker"
+	{
+		"pt"	"★ Talon"
+	}
+	"weapon_knife_css"
+	{
+		"pt"	"★ Classic Knife"
+	}
+	"weapon_knife_cord"
+	{
+		"pt"	"★ Paracord Knife"
+	}
+	"weapon_knife_canis"
+	{
+		"pt"	"★ Survival Knife"
+	}
+	"weapon_knife_outdoor"
+	{
+		"pt"	"★ Nomad Knife"
+	}
+	"weapon_knife_skeleton"
+	{
+		"pt"	"★ Skeleton Knife"
 	}
 	"weapon_knife_t"
 	{
@@ -299,5 +339,97 @@
 	"weapon_knife"
 	{
 		"pt"	"Knife"
+	}
+	"ChangeNameTag"
+	{
+		"pt"	"Set Name Tag"
+	}
+	"NameTagNew"
+	{
+		"pt"	"You can now use !ws menu to set name tag."
+	}
+	"GracePeriod"
+	{
+		"pt"	"You can only use !ws command if you're dead or in the first %d seconds after every round start."
+	}
+	"ChangeLang"
+	{
+		"pt"	"Change Language"
+	}
+	"NameTagCancelled"
+	{
+		"pt"	"Nametag operation aborted."
+	}
+	"Yellow"
+	{
+		"pt"	"Amarelo"
+	}
+	"NameTagInstruction"
+	{
+		"pt"	"Write your desired name tag into chat. To abort, type !cancel."
+	}
+	"NameTagSuccess"
+	{
+		"pt"	"Name tag successfully applied"
+	}
+	"Seed"
+	{
+		"pt"	"Seed"
+	}
+	"SeedTitle"
+	{
+		"pt"	"Seed: %i"
+	}
+	"SeedTitleNoSeed"
+	{
+		"pt"	"Seed: ∞"
+	}
+	"SeedRandom"
+	{
+		"pt"	"Seed Aleatório"
+	}
+	"SeedManual"
+	{
+		"pt"	"Seed Manual"
+	}
+	"SeedSave"
+	{
+		"pt"	"Salvar Seed Atual"
+	}
+	"SeedInstruction"
+	{
+		"pt"	"Write your desired seed into chat. To abort, type !cancel."
+	}
+	"SeedSuccess"
+	{
+		"pt"	"Seed aplicada com sucesso."
+	}
+	"SeedCancelled"
+	{
+		"pt"	"Operação de seed abortada."
+	}
+	"SeedFailed"
+	{
+		"pt"	"Seed inválida (0 - 8192)"
+	}
+	"SeedSaved"
+	{
+		"pt"	"Seed salva."
+	}
+	"SeedDisabled"
+	{
+		"pt"	"O menu de seed está desativado no momento."
+	}
+	"SeedExplanation"
+	{
+		"pt"	"Você deve usar o menu  !ws para definir a seed para skins."
+	}
+	"SeedReset"
+	{
+		"pt"	"Seed reseted."
+	}
+	"ResetSeed"
+	{
+		"pt"	"Resetar Seed"
 	}
 }

--- a/addons/sourcemod/translations/pt/weapons.phrases.txt
+++ b/addons/sourcemod/translations/pt/weapons.phrases.txt
@@ -282,7 +282,7 @@
 	}
 	"weapon_knife_butterfly"
 	{
-		"pt"	"★ Butterfly Knifee"
+		"pt"	"★ Butterfly Knife"
 	}
 	"weapon_knife_falchion"
 	{

--- a/addons/sourcemod/translations/pt/weapons.phrases.txt
+++ b/addons/sourcemod/translations/pt/weapons.phrases.txt
@@ -2,15 +2,15 @@
 {
 	"WSMenuTitle"
 	{
-		"pt"	"Menu de Skins"
+		"pt"	"Weapon Skins Menu"
 	}
 	"ChooseKnife"
 	{
-		"pt"	"★ Mudar sua Faca ★"
+		"pt"	"★ Mudar Faca ★"
 	}
 	"ConfigAllWeapons"
 	{
-		"pt"	"Configurar Todas as Armas"
+		"pt"	"Configurar todas as armas"
 	}
 	"KnifeMenuTitle"
 	{
@@ -30,15 +30,15 @@
 	}
 	"NameTagInfo"
 	{
-		"pt"	"Use !nametag <tag> para escolher uma nametag para sua arma atual!"
+		"pt"	"Use !nametag <tag> para escolher uma name tag para sua arma atual!"
 	}
 	"NameTagColor"
 	{
-		"pt"	"Escolher cor da nametag"
+		"pt"	"Escolher Cor da Name Tag"
 	}
 	"NameTagDisabled"
 	{
-		"pt"	"O uso da nametag está desabilitado no momento."
+		"pt"	"O uso da name tag está desabilitado no momento."
 	}
 	"DontSpamNameTag"
 	{
@@ -78,7 +78,7 @@
 	}
 	"Red"
 	{
-		"pt"	"Encarnado"
+		"pt"	"Vermelho"
 	}
 	"Green"
 	{
@@ -90,7 +90,7 @@
 	}
 	"DeleteNameTag"
 	{
-		"pt"	"Apagar NameTag"
+		"pt"	"Apagar Name Tag"
 	}
 	"OwnKnife"
 	{
@@ -110,7 +110,7 @@
 	}
 	"SetNameTag"
 	{
-		"pt"	"NameTag"
+		"pt"	"Name Tag"
 	}
 	"On"
 	{
@@ -342,7 +342,7 @@
 	}
 	"ChangeNameTag"
 	{
-		"pt"	"Set Name Tag"
+		"pt"	"Definir Name Tag"
 	}
 	"NameTagNew"
 	{
@@ -354,11 +354,11 @@
 	}
 	"ChangeLang"
 	{
-		"pt"	"Change Language"
+		"pt"	"Mudar Idioma"
 	}
 	"NameTagCancelled"
 	{
-		"pt"	"Nametag operation aborted."
+		"pt"	"Operação da name tag foi abortada."
 	}
 	"Yellow"
 	{

--- a/addons/sourcemod/translations/pt/weapons.phrases.txt
+++ b/addons/sourcemod/translations/pt/weapons.phrases.txt
@@ -114,11 +114,11 @@
 	}
 	"On"
 	{
-		"pt"	"Ligado"
+		"pt"	"ON"
 	}
 	"Off"
 	{
-		"pt"	"Desligado"
+		"pt"	"OFF"
 	}
 	"weapon_galilar"
 	{
@@ -346,11 +346,11 @@
 	}
 	"NameTagNew"
 	{
-		"pt"	"You can now use !ws menu to set name tag."
+		"pt"	"Agora você pode usar o menu !ws para definir a name tag."
 	}
 	"GracePeriod"
 	{
-		"pt"	"You can only use !ws command if you're dead or in the first %d seconds after every round start."
+		"pt"	"Você só pode usar o comando !ws se estiver morto ou nos primeiros %d segundos após o início de cada round."
 	}
 	"ChangeLang"
 	{
@@ -366,11 +366,11 @@
 	}
 	"NameTagInstruction"
 	{
-		"pt"	"Write your desired name tag into chat. To abort, type !cancel."
+		"pt"	"Escreva a name tag desejada no chat. Para abortar, digite !cancel."
 	}
 	"NameTagSuccess"
 	{
-		"pt"	"Name tag successfully applied"
+		"pt"	"Name tag aplicada com sucesso"
 	}
 	"Seed"
 	{
@@ -398,7 +398,7 @@
 	}
 	"SeedInstruction"
 	{
-		"pt"	"Write your desired seed into chat. To abort, type !cancel."
+		"pt"	"Escreva a seed desejada no chat. Para abortar, digite !cancel."
 	}
 	"SeedSuccess"
 	{

--- a/addons/sourcemod/translations/pt/weapons.phrases.txt
+++ b/addons/sourcemod/translations/pt/weapons.phrases.txt
@@ -350,7 +350,7 @@
 	}
 	"GracePeriod"
 	{
-		"pt"	"Você só pode usar o comando !ws se estiver morto ou nos primeiros %d segundos após o início de cada round."
+		"pt"	"Você só pode usar este comando se estiver morto ou nos primeiros %d segundos após o início de cada round."
 	}
 	"ChangeLang"
 	{

--- a/addons/sourcemod/translations/weapons.phrases.txt
+++ b/addons/sourcemod/translations/weapons.phrases.txt
@@ -28,6 +28,10 @@
 	{
 		"en"	"Decrease by %d%%"
 	}
+	"NameTagInfo"
+	{
+		"en"	"Use !nametag <tag> to choose a nametag for your current weapon!"
+	}	  
 	"NameTagColor"
 	{
 		"en"	"Set Name Tag Color"
@@ -35,6 +39,14 @@
 	"NameTagDisabled"
 	{
 		"en"	"Name tag usage is disabled at the moment."
+	}
+	"DontSpamNameTag"
+	{
+		"en"	"Wait a while before using !nametag."
+	}
+	"NameTagNeedsParams"
+	{
+		"en"	"Use: !nametag <tag>"
 	}
 	"ChooseLanguage"
 	{
@@ -126,7 +138,7 @@
 	}
 	"weapon_revolver"
 	{
-		"en"	"Revolver"
+		"en"	"R8 Revolver"
 	}
 	"weapon_deagle"
 	{
@@ -410,7 +422,7 @@
 	}
 	"SeedReset"
 	{
-		"en"	"Seed reset."
+		"en"	"Seed reseted."
 	}
 	"ResetSeed"
 	{

--- a/addons/sourcemod/translations/weapons.phrases.txt
+++ b/addons/sourcemod/translations/weapons.phrases.txt
@@ -30,7 +30,7 @@
 	}
 	"NameTagInfo"
 	{
-		"en"	"Use !nametag <tag> to choose a nametag for your current weapon!"
+		"en"	"Use !nametag <tag> to choose a name tag for your current weapon!"
 	}	  
 	"NameTagColor"
 	{
@@ -72,6 +72,10 @@
 	{
 		"en"	"Black"
 	}
+	"Grey"
+	{
+		"en"	"Grey"
+	} 
 	"Red"
 	{
 		"en"	"Red"
@@ -354,7 +358,7 @@
 	}
 	"NameTagCancelled"
 	{
-		"en"	"Nametag operation aborted."
+		"en"	"Name tag operation aborted."
 	}
 	"Yellow"
 	{

--- a/addons/sourcemod/translations/weapons.phrases.txt
+++ b/addons/sourcemod/translations/weapons.phrases.txt
@@ -350,7 +350,7 @@
 	}
 	"GracePeriod"
 	{
-		"en"	"You can only use !ws command if you're dead or in the first %d seconds after every round start."
+		"en"	"You can only use this command if you're dead or in the first %d seconds after every round start."
 	}
 	"ChangeLang"
 	{

--- a/cfg/sourcemod/weapons.cfg
+++ b/cfg/sourcemod/weapons.cfg
@@ -44,12 +44,12 @@ sm_weapons_float_increment_size "0.05"
 // Grace period in terms of seconds counted after round start for allowing the use of !ws command. 0 means no restrictions
 // -
 // Default: "0"
-sm_weapons_grace_period 0
+sm_weapons_grace_period "0"
 
 // Number of days before a player (SteamID) is marked as inactive and his data is deleted. (0 or any negative value to disable deleting)
 // -
 // Default: "30"
-sm_weapons_inactive_days 30
+sm_weapons_inactive_days "30"
 
 // 0: All knives have same StatTrak counter 1: Each type of knife has its separate StatTrak counter
 // -


### PR DESCRIPTION
- Add more Portuguese-BR translations;
- Fix English translations;
- Fix minors in the generated config; _(Just for the sake of visualization)_

I tested it on my servers, both translations working correctly.

In the English translations I noticed that some were missing, I just completed.

And I changed the translation of **GracePeriod**:
```
"GracePeriod"
	{
		"en"	"You can only use !ws command if you're dead or in the first %d seconds after every round start."
		"en"	"You can only use this command if you're dead or in the first %d seconds after every round start."
	}
```
Since using the `!knife` command after the configured timeout he would send the message as if he had used the `!ws` command.