### PR TITLE
Increase Index

### DIFF
--- a/addons/sourcemod/scripting/weapons/config.sp
+++ b/addons/sourcemod/scripting/weapons/config.sp
@@ -72,7 +72,7 @@ public void ReadConfig()
 		char weaponTemp[20];
 		do {
 			char name[64];
-			char index[4];
+			char index[5];
 			char classes[1024];
 			
 			KvGetSectionName(kv, name, sizeof(name));


### PR DESCRIPTION
After the new update certain skins like the AK-47 XRay do not get the correct skin due to the config only allowing an index of 4. When bumped to 5 this fixes the error.