### PR TITLE
Implement skins search

### DIFF
--- a/addons/sourcemod/scripting/weapons.sp
+++ b/addons/sourcemod/scripting/weapons.sp
@@ -206,14 +206,21 @@ public Action CommandWeaponSkins(int client, int args)
 		{
 			if (args > 0) {
 				
-				char searchSkinName[32];
-				GetCmdArgString(searchSkinName, sizeof(searchSkinName));
-				
-				Menu resultMenu = SearchSkins(client, searchSkinName);
-				menuPlayerSearchTemp[client] = resultMenu;
-				resultMenu.Display(client, menuTime);
-				
+				if (g_bEnableSearch)
+				{
+					char searchSkinName[32];
+					GetCmdArgString(searchSkinName, sizeof(searchSkinName));
+					
+					Menu resultMenu = SearchSkins(client, searchSkinName);
+					menuPlayerSearchTemp[client] = resultMenu;
+					resultMenu.Display(client, menuTime);
+				}
+				else
+				{
+					PrintToChat(client, " %s \x02%T", g_ChatPrefix, "SearchDisabled");
+				}
 				return Plugin_Handled;
+				
 			}
 			
 			CreateMainMenu(client).Display(client, menuTime);

--- a/addons/sourcemod/scripting/weapons.sp
+++ b/addons/sourcemod/scripting/weapons.sp
@@ -23,6 +23,7 @@
 #include <weapons>
 #undef REQUIRE_PLUGIN
 #include <updater>
+#include <regex>
 
 #pragma semicolon 1
 #pragma newdecls required
@@ -88,6 +89,7 @@ public void OnPluginStart()
 	g_Cvar_EnableNameTag 			= CreateConVar("sm_weapons_enable_nametag", 		"1", 				"Enable/Disable name tag options");
 	g_Cvar_EnableStatTrak 			= CreateConVar("sm_weapons_enable_stattrak", 		"1", 				"Enable/Disable StatTrak options");
 	g_Cvar_EnableSeed				= CreateConVar("sm_weapons_enable_seed",			"1",				"Enable/Disable Seed options");
+	g_Cvar_EnableSearch             = CreateConVar("sm_weapons_enable_search",          "1",                "Enable/Disable Search Function");
 	g_Cvar_FloatIncrementSize 		= CreateConVar("sm_weapons_float_increment_size", 	"0.05", 			"Increase/Decrease by value for weapon float");
 	g_Cvar_EnableWeaponOverwrite 	= CreateConVar("sm_weapons_enable_overwrite", 		"1", 				"Enable/Disable players overwriting other players' weapons (picked up from the ground) by using !ws command");
 	g_Cvar_GracePeriod 			= CreateConVar("sm_weapons_grace_period", 			"0", 				"Grace period in terms of seconds counted after round start for allowing the use of !ws command. 0 means no restrictions");
@@ -202,6 +204,18 @@ public Action CommandWeaponSkins(int client, int args)
 		int menuTime;
 		if((menuTime = GetRemainingGracePeriodSeconds(client)) >= 0)
 		{
+			if (args > 0) {
+				
+				char searchSkinName[32];
+				GetCmdArgString(searchSkinName, sizeof(searchSkinName));
+				
+				Menu resultMenu = SearchSkins(client, searchSkinName);
+				menuPlayerSearchTemp[client] = resultMenu;
+				resultMenu.Display(client, menuTime);
+				
+				return Plugin_Handled;
+			}
+			
 			CreateMainMenu(client).Display(client, menuTime);
 		}
 		else
@@ -209,6 +223,7 @@ public Action CommandWeaponSkins(int client, int args)
 			PrintToChat(client, " %s \x02%t", g_ChatPrefix, "GracePeriod", g_iGracePeriod);
 		}
 	}
+	
 	return Plugin_Handled;
 }
 

--- a/addons/sourcemod/scripting/weapons/forwards.sp
+++ b/addons/sourcemod/scripting/weapons/forwards.sp
@@ -44,6 +44,7 @@ public void OnConfigsExecuted()
 	g_bEnableNameTag = g_Cvar_EnableNameTag.BoolValue;
 	g_bEnableStatTrak = g_Cvar_EnableStatTrak.BoolValue;
 	g_bEnableSeed = g_Cvar_EnableSeed.BoolValue;
+	g_bEnableSearch = g_Cvar_EnableSearch.BoolValue;
 	g_fFloatIncrementSize = g_Cvar_FloatIncrementSize.FloatValue;
 	g_iFloatIncrementPercentage = RoundFloat(g_fFloatIncrementSize * 100.0);
 	g_bOverwriteEnabled = g_Cvar_EnableWeaponOverwrite.BoolValue;

--- a/addons/sourcemod/scripting/weapons/globals.sp
+++ b/addons/sourcemod/scripting/weapons/globals.sp
@@ -40,6 +40,7 @@ int g_iKnifeIndices[] = {
 };
 
 const int MAX_LANG = 40;
+const int MAX_SKIN = 1255;
 
 Database db = null;
 
@@ -73,6 +74,9 @@ bool g_bEnableStatTrak;
 
 ConVar g_Cvar_EnableSeed;
 bool g_bEnableSeed;
+
+ConVar g_Cvar_EnableSearch;
+bool g_bEnableSearch;
 
 ConVar g_Cvar_EnableWeaponOverwrite;
 bool g_bOverwriteEnabled;
@@ -120,10 +124,12 @@ char g_MigrationWeapons[][] = {
 char g_Language[MAX_LANG][32];
 int g_iClientLanguage[MAXPLAYERS+1];
 Menu menuWeapons[MAX_LANG][sizeof(g_WeaponClasses)];
+Menu menuPlayerSearchTemp[MAXPLAYERS+1];
 
 StringMap g_smWeaponIndex;
 StringMap g_smWeaponDefIndex;
 StringMap g_smLanguageIndex;
+StringMap g_smSkinMenuMap[MAX_LANG];
 
 GlobalForward g_hOnKnifeSelect_Pre;
 GlobalForward g_hOnKnifeSelect_Post;

--- a/addons/sourcemod/scripting/weapons/helpers.sp
+++ b/addons/sourcemod/scripting/weapons/helpers.sp
@@ -262,3 +262,34 @@ bool IsWarmUpPeriod()
 {
 	return view_as<bool>(GameRules_GetProp("m_bWarmupPeriod"));
 }
+
+int GetSkinIdFromSkinMenuDisplay(char display[32])
+{
+	Regex regex = CompileRegex(".+ \\((.+)\\)");
+	regex.Match(display);
+	
+	char skinIdStr[32];
+	regex.GetSubString(1, skinIdStr, sizeof(skinIdStr));
+	return StringToInt(skinIdStr);
+}
+
+Menu SearchSkins(int client, char skinName[32])
+{
+	StringMapSnapshot snapshot = g_smSkinMenuMap[g_iClientLanguage[client]].Snapshot();
+	menuPlayerSearchTemp[client] = null;
+	Menu result = new Menu(SearchMenuHandler, MENU_ACTIONS_DEFAULT);
+	
+	for (int i = 0; i < snapshot.Length; i++)
+	{
+		char name[32]
+		snapshot.GetKey(i, name, sizeof(name));
+		
+		// if current menu is the menu we searched for
+		if (StrContains(skinName, name, false) > -1 || StrContains(name, skinName, false) > -1)
+		{
+			result.AddItem(name, name);
+		}
+	}
+	
+	return result;
+}

--- a/addons/sourcemod/translations/chi/weapons.phrases.txt
+++ b/addons/sourcemod/translations/chi/weapons.phrases.txt
@@ -56,6 +56,10 @@
 	{
 		"chi"	"名称标签已禁用"
 	}
+	"SearchDisabled"
+	{
+		"chi"	"搜索功能已禁用"
+	}
 	"SearchApplyAll"
 	{
 		"chi"	"应用所有皮肤"

--- a/addons/sourcemod/translations/chi/weapons.phrases.txt
+++ b/addons/sourcemod/translations/chi/weapons.phrases.txt
@@ -56,6 +56,18 @@
 	{
 		"chi"	"名称标签已禁用"
 	}
+	"SearchApplyAll"
+	{
+		"chi"	"应用所有皮肤"
+	}
+	"SearchApplyCurrent"
+	{
+		"chi"	"应用到当前武器"
+	}
+	"SearchApplyCurrentFailed"
+	{
+		"chi"	"您的武器没有该皮肤。"
+	}
 	"ChooseLanguage"
 	{
 		"chi"	"请选择皮肤名称显示语言："

--- a/addons/sourcemod/translations/weapons.phrases.txt
+++ b/addons/sourcemod/translations/weapons.phrases.txt
@@ -68,6 +68,10 @@
 	{
 		"en"	"Use: !nametag <tag>"
 	}
+	"SearchDisabled"
+	{
+		"en"	"Skin search is disabled at the moment."
+	}
 	"SearchApplyAll"
 	{
 		"en"	"Apply to all"

--- a/addons/sourcemod/translations/weapons.phrases.txt
+++ b/addons/sourcemod/translations/weapons.phrases.txt
@@ -68,6 +68,18 @@
 	{
 		"en"	"Use: !nametag <tag>"
 	}
+	"SearchApplyAll"
+	{
+		"en"	"Apply to all"
+	}
+	"SearchApplyCurrent"
+	{
+		"en"	"Apply to current"
+	}
+	"SearchApplyCurrentFailed"
+	{
+		"en"	"Your weapon doesn't have this skin."
+	}
 	"ChooseLanguage"
 	{
 		"en"	"Select language for skin names:"


### PR DESCRIPTION
For #273, @crashzk 
This code can enable player to search skins.

## Usage
1. Type `!ws <skin name>` to search
like `!ws asi`
and it will show a menu like this:
![QQ截图20230527082354](https://github.com/kgns/weapons/assets/60744529/76666fd4-cb9e-4ad5-b98d-c8e51948b324)
2. Click the skin you want
then it will show a menu like this:
![QQ截图20230527082549](https://github.com/kgns/weapons/assets/60744529/8bd866a7-f0e9-4f5d-8919-a8a201875b35)
## Options
- **Apply All**: Apply to all weapons that have this skin (with their own skin id)
- **Apply current**: Apply to the weapon in player hand with its skin id, if the weapon in player hand doesn't have this skin, it will return `SearchApplyCurrentFailed` phrase.
- **Specified weapon**: this option IS NOT designed for applying the skin to specified weapon
some skins, like Asiimov, has different skin id for different weapons ( 801 for AK47, 551 for P250)
this option can apply the skin id you selected to the weapon in your hand (even if the weapon doesn't originally have this skin)
the reason i designed it like this because i think this will be more fun and useful ( because player can just hold the specified weapon in their hand and click 'Apply current' option instead of setting with this option)
## Translation Phrase
- SearchDisabled
- SearchApplyAll
- SearchApplyCurrent
- SearchApplyCurrentFailed

## TODO
since #271 add a cvar `sm_weapons_enable_all_skins`, we need to do a check before player use the specified weapon options ( or just disable all the specified weapon options )