### PR TITLE
fix Portuguese translations

### DIFF
--- a/addons/sourcemod/translations/pt/weapons.phrases.txt
+++ b/addons/sourcemod/translations/pt/weapons.phrases.txt
@@ -98,7 +98,7 @@
 	}
 	"RandomKnife"
 	{
-		"en"	"★ Faca Aleatória"
+		"pt"	"★ Faca Aleatória"
 	}
 	"SetSkin"
 	{


### PR DESCRIPTION
Portuguese for "Random Knife" was showing up in English, this fixes it.